### PR TITLE
Differentiate TOC header levels with tab instead of dots

### DIFF
--- a/OneMore/Commands/Snippets/InsertTocCommand.cs
+++ b/OneMore/Commands/Snippets/InsertTocCommand.cs
@@ -128,7 +128,7 @@ namespace River.OneMoreAddIn.Commands
 				var count = minlevel;
 				while (count < heading.Style.Index)
 				{
-					text.Append(". . ");
+					text.Append("\t");
 					count++;
 				}
 

--- a/OneMore/Commands/Snippets/InsertTocCommand.cs
+++ b/OneMore/Commands/Snippets/InsertTocCommand.cs
@@ -198,7 +198,7 @@ namespace River.OneMoreAddIn.Commands
 				var level = int.Parse(element.Attribute("pageLevel").Value);
 				while (level > 0)
 				{
-					text.Append(". . ");
+					text.Append("\t");
 					level--;
 				}
 
@@ -322,7 +322,7 @@ namespace River.OneMoreAddIn.Commands
 							var plevel = int.Parse(page.Attribute("pageLevel").Value);
 							while (plevel > 0)
 							{
-								text.Append(". . ");
+								text.Append("\t");
 								plevel--;
 							}
 


### PR DESCRIPTION
Header levels in the TOC are currently differentiated by two dots. Using a tab instead would make it look cleaner, if using them in a string doesn't lead to any problems. I've tested it and it seems fine.
Screenshot:
![image](https://user-images.githubusercontent.com/38046772/110416571-308a2c00-8051-11eb-875f-7964acd7f3b5.png)
