### PR TITLE
Add VS Community devenv path to build script

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -28,6 +28,10 @@ Begin
         {
             $script:devenv = Join-Path $0 'Professional\Common7\IDE\devenv.com'
         }
+        if (!(Test-Path $devenv))
+        {
+            $script:devenv = Join-Path $0 'Community\Common7\IDE\devenv.com'
+        }
 
         if (!(Test-Path $devenv))
         {


### PR DESCRIPTION
I had to add this for the build script to work, it was otherwise unable to find the devenv.