### PR TITLE
469-remove-para-spacing-for-selected

### DIFF
--- a/OneMore/Commands/Clean/RemoveSpacingCommand.cs
+++ b/OneMore/Commands/Clean/RemoveSpacingCommand.cs
@@ -57,6 +57,12 @@ namespace River.OneMoreAddIn.Commands
 						e.Attribute("spaceBetween") != null)
 					.ToList();
 
+				page.GetTextCursor();
+				if (page.SelectionScope != SelectionScope.Empty)
+				{
+					elements = elements.Where(e => e.Attribute("selected") != null).ToList();
+				}
+
 				if (elements.Count == 0)
 				{
 					logger.StopClock();


### PR DESCRIPTION
If there is a selection region, remove paragraph spacing for only paragraphs in the region. Otherwise default to modifying all paragraphs on the entire page.