### PR TITLE
replace "new footnote" with angle bracket

### DIFF
--- a/OneMore/Commands/References/FootnoteEditor.cs
+++ b/OneMore/Commands/References/FootnoteEditor.cs
@@ -257,7 +257,7 @@ namespace River.OneMoreAddIn
 				cdata = new XElement("wrapper",
 					new XElement("span",
 						new XAttribute("style", "font-family:'Calibri Light';font-size:11.0pt"),
-						"new footnote "),
+						"< "),
 					cdatalink
 					);
 			}
@@ -266,7 +266,7 @@ namespace River.OneMoreAddIn
 				cdata = new XElement("wrapper", cdatalink,
 					new XElement("span",
 						new XAttribute("style", "font-family:'Calibri Light';font-size:11.0pt"),
-						" new footnote")
+						" >")
 					);
 			}
 


### PR DESCRIPTION
## Enhancement or Defect Addressed by This PR
"new footnote" leader text is too wordy and requires removal every time

## Description of Proposed Changes
Replace "new footnote" text with angle brackets, greater-than for LTR languages, and less-than for RTL languages
