### PR TITLE
include page-level images outside of any Outline

### DIFF
--- a/OneMore/Commands/File/MarkdownWriter.cs
+++ b/OneMore/Commands/File/MarkdownWriter.cs
@@ -113,6 +113,13 @@ namespace River.OneMoreAddIn.Commands
 					.Elements()
 					.ForEach(e => Write(e));
 
+				// page level Images outside of any Outline
+				page.Root.Elements(ns + "Image")
+					.ForEach(e => {
+						Write(e);
+						writer.WriteLine();
+					});
+
 				writer.WriteLine();
 			}
 		}


### PR DESCRIPTION
## Enhancement or Defect Addressed by This PR
Page-level image, outside of any Outline, were not included when exporting as Markdown

## Description of Proposed Changes
Append page-level images to end of document in order in which they are described in the page XML
