### PR TITLE
restore use of owner window, use new owner for every command

### DIFF
--- a/OneMore/AddIn.cs
+++ b/OneMore/AddIn.cs
@@ -209,12 +209,7 @@ namespace River.OneMoreAddIn
 				// hotkeys
 				Task.Run(async () => { await RegisterHotkeys(); });
 
-				using (var one = new OneNote())
-				{
-					factory = new CommandFactory(logger, ribbon, trash,
-						// looks complicated but necessary for this to work
-						new Win32WindowHandle(new IntPtr((long)one.WindowHandle)));
-				}
+				factory = new CommandFactory(logger, ribbon, trash);
 
 				// command listener for Refresh links
 				new CommandService(factory).Startup();

--- a/OneMore/Commands/Clean/BreakingCommand.cs
+++ b/OneMore/Commands/Clean/BreakingCommand.cs
@@ -36,7 +36,7 @@ namespace River.OneMoreAddIn.Commands
 			bool singleSpace = true;
 			using (var dialog = new BreakingDialog())
 			{
-				if (dialog.ShowDialog() != DialogResult.OK)
+				if (dialog.ShowDialog(owner) != DialogResult.OK)
 				{
 					return;
 				}

--- a/OneMore/Commands/Clean/RemoveDuplicatesCommand.cs
+++ b/OneMore/Commands/Clean/RemoveDuplicatesCommand.cs
@@ -62,7 +62,7 @@ namespace River.OneMoreAddIn.Commands
 
 			using (var dialog = new RemoveDuplicatesDialog())
 			{
-				result = dialog.ShowDialog();
+				result = dialog.ShowDialog(owner);
 				if (result != DialogResult.OK)
 				{
 					return;

--- a/OneMore/Commands/Clean/RemoveSpacingCommand.cs
+++ b/OneMore/Commands/Clean/RemoveSpacingCommand.cs
@@ -31,7 +31,7 @@ namespace River.OneMoreAddIn.Commands
 		public override async Task Execute(params object[] args)
 		{
 			using var dialog = new RemoveSpacingDialog();
-			if (dialog.ShowDialog() == DialogResult.OK)
+			if (dialog.ShowDialog(owner) == DialogResult.OK)
 			{
 				spaceBefore = dialog.SpaceBefore;
 				spaceAfter = dialog.SpaceAfter;

--- a/OneMore/Commands/Clean/ToggleDttmCommand.cs
+++ b/OneMore/Commands/Clean/ToggleDttmCommand.cs
@@ -26,7 +26,7 @@ namespace River.OneMoreAddIn.Commands
 		public override async Task Execute(params object[] args)
 		{
 			using var dialog = new ToggleDttmDialog();
-			if (dialog.ShowDialog() == DialogResult.OK)
+			if (dialog.ShowDialog(owner) == DialogResult.OK)
 			{
 				await Toggle(dialog.PageOnly, dialog.ShowTimestamps);
 			}

--- a/OneMore/Commands/Command.cs
+++ b/OneMore/Commands/Command.cs
@@ -39,24 +39,6 @@ namespace River.OneMoreAddIn
 		}
 
 
-		/// <summary>
-		/// Gets the main OneNote window
-		/// </summary>
-		public IWin32Window Owner
-		{
-			get
-			{
-				if (owner == null || !Native.IsWindow(owner.Handle))
-				{
-					using var one = new OneNote();
-					owner = one.Window;
-				}
-
-				return owner;
-			}
-		}
-
-
 		// = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 		// Settings used by CommandFactory
 

--- a/OneMore/Commands/Edit/PronunciateCommand.cs
+++ b/OneMore/Commands/Edit/PronunciateCommand.cs
@@ -94,7 +94,7 @@ namespace River.OneMoreAddIn.Commands
 				using var dialog = new PronunciateDialog();
 				dialog.Word = word;
 
-				if (dialog.ShowDialog() != DialogResult.OK)
+				if (dialog.ShowDialog(owner) != DialogResult.OK)
 				{
 					IsCancelled = true;
 					return;

--- a/OneMore/Commands/Edit/SortListCommand.cs
+++ b/OneMore/Commands/Edit/SortListCommand.cs
@@ -51,7 +51,7 @@ namespace River.OneMoreAddIn.Commands
 			}
 
 			using var dialog = new SortListDialog();
-			var result = dialog.ShowDialog();
+			var result = dialog.ShowDialog(owner);
 			if (result == DialogResult.Cancel)
 			{
 				return;

--- a/OneMore/Commands/Extras/AnalyzeCommand.cs
+++ b/OneMore/Commands/Extras/AnalyzeCommand.cs
@@ -79,7 +79,7 @@ namespace River.OneMoreAddIn.Commands
 
 				using (var dialog = new AnalyzeDialog())
 				{
-					if (dialog.ShowDialog() != DialogResult.OK)
+					if (dialog.ShowDialog(owner) != DialogResult.OK)
 					{
 						return;
 					}

--- a/OneMore/Commands/Extras/SectionColorCommand.cs
+++ b/OneMore/Commands/Extras/SectionColorCommand.cs
@@ -53,7 +53,7 @@ namespace River.OneMoreAddIn.Commands
 			// use the elevator to force ColorDialog to top-most first time used
 			// otherwise, it will be hidden by the OneMore window
 			using var elevator = new UI.WindowElevator(dialog);
-			var result = elevator.ShowDialog();
+			var result = elevator.ShowDialog(owner);
 			if (result == DialogResult.OK)
 			{
 				section.SetAttributeValue("color", dialog.Color.ToRGBHtml());

--- a/OneMore/Commands/Extras/SortCommand.cs
+++ b/OneMore/Commands/Extras/SortCommand.cs
@@ -56,7 +56,7 @@ namespace River.OneMoreAddIn.Commands
 				dialog.SetScope(scopeArg);
 			}
 
-			if (dialog.ShowDialog() != DialogResult.OK)
+			if (dialog.ShowDialog(owner) != DialogResult.OK)
 			{
 				return;
 			}

--- a/OneMore/Commands/Favorites/GotoFavoriteCommand.cs
+++ b/OneMore/Commands/Favorites/GotoFavoriteCommand.cs
@@ -26,7 +26,7 @@ namespace River.OneMoreAddIn.Commands
 			if (uri == null)
 			{
 				using var dialog = new FavoritesDialog();
-				if (dialog.ShowDialog() == DialogResult.Cancel)
+				if (dialog.ShowDialog(owner) == DialogResult.Cancel)
 				{
 					return;
 				}

--- a/OneMore/Commands/Favorites/ManageFavoritesCommand.cs
+++ b/OneMore/Commands/Favorites/ManageFavoritesCommand.cs
@@ -20,7 +20,7 @@ namespace River.OneMoreAddIn.Commands
 			using (var dialog = new SettingsDialog(args[0] as IRibbonUI))
 			{
 				dialog.ActivateSheet(SettingsDialog.Sheets.Favorites);
-				dialog.ShowDialog();
+				dialog.ShowDialog(owner);
 			}
 
 			await Task.Yield();

--- a/OneMore/Commands/File/CrawlWebPageCommand.cs
+++ b/OneMore/Commands/File/CrawlWebPageCommand.cs
@@ -49,7 +49,7 @@ namespace River.OneMoreAddIn.Commands
 
 				using (var dialog = new CrawlWebPageDialog(candidates))
 				{
-					if (dialog.ShowDialog() != DialogResult.OK)
+					if (dialog.ShowDialog(owner) != DialogResult.OK)
 					{
 						return;
 					}

--- a/OneMore/Commands/File/ExportCommand.cs
+++ b/OneMore/Commands/File/ExportCommand.cs
@@ -65,7 +65,7 @@ namespace River.OneMoreAddIn.Commands
 
 			using (var dialog = new ExportDialog(pageIDs.Count))
 			{
-				if (dialog.ShowDialog() != DialogResult.OK)
+				if (dialog.ShowDialog(owner) != DialogResult.OK)
 				{
 					return;
 				}

--- a/OneMore/Commands/File/ExportDialog.cs
+++ b/OneMore/Commands/File/ExportDialog.cs
@@ -133,7 +133,7 @@ namespace River.OneMoreAddIn.Commands
 					};
 
 					// cannot use owner parameter here or it will hang! cross-threading
-					if (dialog.ShowDialog() == DialogResult.OK)
+					if (dialog.ShowDialog(/* leave empty */) == DialogResult.OK)
 					{
 						path = dialog.SelectedPath;
 					}

--- a/OneMore/Commands/File/ImportCommand.cs
+++ b/OneMore/Commands/File/ImportCommand.cs
@@ -44,7 +44,7 @@ namespace River.OneMoreAddIn.Commands
 		{
 			using var dialog = new ImportDialog();
 
-			if (dialog.ShowDialog() != DialogResult.OK)
+			if (dialog.ShowDialog(owner) != DialogResult.OK)
 			{
 				return;
 			}

--- a/OneMore/Commands/File/ImportDialog.cs
+++ b/OneMore/Commands/File/ImportDialog.cs
@@ -192,7 +192,7 @@ namespace River.OneMoreAddIn.Commands
 					})
 					{
 						// cannot use owner parameter here or it will hang! cross-threading
-						if (dialog.ShowDialog() == DialogResult.OK)
+						if (dialog.ShowDialog(/* leave empty */) == DialogResult.OK)
 						{
 							return dialog.FileName;
 						}

--- a/OneMore/Commands/File/ImportWebCommand.cs
+++ b/OneMore/Commands/File/ImportWebCommand.cs
@@ -64,7 +64,7 @@ namespace River.OneMoreAddIn.Commands
 
 			using (var dialog = new ImportWebDialog())
 			{
-				if (dialog.ShowDialog() != DialogResult.OK)
+				if (dialog.ShowDialog(owner) != DialogResult.OK)
 				{
 					return;
 				}
@@ -507,7 +507,7 @@ namespace River.OneMoreAddIn.Commands
 						return true;
 					}));
 
-				form.ShowDialog();
+				form.ShowDialog(/* leave empty */);
 			});
 
 			if (!string.IsNullOrWhiteSpace(title) &&

--- a/OneMore/Commands/File/ManagePluginsCommand.cs
+++ b/OneMore/Commands/File/ManagePluginsCommand.cs
@@ -20,7 +20,7 @@ namespace River.OneMoreAddIn.Commands
 			using (var dialog = new SettingsDialog(args[0] as IRibbonUI))
 			{
 				dialog.ActivateSheet(SettingsDialog.Sheets.Plugins);
-				dialog.ShowDialog();
+				dialog.ShowDialog(owner);
 			}
 
 			await Task.Yield();

--- a/OneMore/Commands/File/PluginDialog.cs
+++ b/OneMore/Commands/File/PluginDialog.cs
@@ -351,7 +351,7 @@ namespace River.OneMoreAddIn.Commands
 			dialog.ShowHelp = true; // stupid, but this is needed to avoid hang
 			dialog.InitialDirectory = GetValidPath(box.Text);
 
-			var result = dialog.ShowDialog();
+			var result = dialog.ShowDialog(/* leave empty */);
 			if (result == DialogResult.OK)
 			{
 				box.Text = dialog.FileName;

--- a/OneMore/Commands/File/RunPluginCommand.cs
+++ b/OneMore/Commands/File/RunPluginCommand.cs
@@ -111,7 +111,7 @@ namespace River.OneMoreAddIn.Commands
 				PageName = "$name (2)"
 			};
 
-			if (dialog.ShowDialog() == DialogResult.Cancel)
+			if (dialog.ShowDialog(owner) == DialogResult.Cancel)
 			{
 				plugin = null;
 				return false;
@@ -170,7 +170,7 @@ namespace River.OneMoreAddIn.Commands
 
 				box.AppendMessage(" Do you wish to continue?");
 
-				if (box.ShowDialog(Owner) == DialogResult.No)
+				if (box.ShowDialog(owner) == DialogResult.No)
 				{
 					return null;
 				}

--- a/OneMore/Commands/Images/CropImageCommand.cs
+++ b/OneMore/Commands/Images/CropImageCommand.cs
@@ -69,7 +69,7 @@ namespace River.OneMoreAddIn.Commands
 			var scales = new SizeF(width / image.Width, height / image.Height);
 
 			using var dialog = new CropImageDialog(image);
-			var result = dialog.ShowDialog();
+			var result = dialog.ShowDialog(owner);
 			if (result == DialogResult.OK)
 			{
 				var bytes = (byte[])new ImageConverter()

--- a/OneMore/Commands/Images/ResizeImagesCommand.cs
+++ b/OneMore/Commands/Images/ResizeImagesCommand.cs
@@ -83,7 +83,7 @@ namespace River.OneMoreAddIn.Commands
 			}
 
 			using var dialog = new ResizeImagesDialog(image, viewWidth, viewHeight);
-			var result = dialog.ShowDialog();
+			var result = dialog.ShowDialog(owner);
 			if (result != DialogResult.OK)
 			{
 				return;
@@ -111,7 +111,7 @@ namespace River.OneMoreAddIn.Commands
 		private async Task ResizeMany(IEnumerable<XElement> elements)
 		{
 			using var dialog = new ResizeImagesDialog();
-			var result = dialog.ShowDialog();
+			var result = dialog.ShowDialog(owner);
 			if (result != DialogResult.OK)
 			{
 				return;

--- a/OneMore/Commands/Numbering/NumberPagesCommand.cs
+++ b/OneMore/Commands/Numbering/NumberPagesCommand.cs
@@ -38,7 +38,7 @@ namespace River.OneMoreAddIn.Commands
 		public override async Task Execute(params object[] args)
 		{
 			using var dialog = new NumberPagesDialog();
-			if (dialog.ShowDialog() != DialogResult.OK)
+			if (dialog.ShowDialog(owner) != DialogResult.OK)
 			{
 				return;
 			}

--- a/OneMore/Commands/Numbering/OutlineCommand.cs
+++ b/OneMore/Commands/Numbering/OutlineCommand.cs
@@ -31,7 +31,7 @@ namespace River.OneMoreAddIn.Commands
 		public override async Task Execute(params object[] args)
 		{
 			using var dialog = new OutlineDialog();
-			if (dialog.ShowDialog() != DialogResult.OK)
+			if (dialog.ShowDialog(owner) != DialogResult.OK)
 			{
 				return;
 			}

--- a/OneMore/Commands/Page/AddTitleIconCommand.cs
+++ b/OneMore/Commands/Page/AddTitleIconCommand.cs
@@ -35,7 +35,7 @@ namespace River.OneMoreAddIn.Commands
 			if (codes == null)
 			{
 				using var dialog = new AddTitleIconDialog();
-				if (dialog.ShowDialog() == DialogResult.Cancel)
+				if (dialog.ShowDialog(owner) == DialogResult.Cancel)
 				{
 					IsCancelled = true;
 					return;

--- a/OneMore/Commands/Page/ArrangeContainersCommand.cs
+++ b/OneMore/Commands/Page/ArrangeContainersCommand.cs
@@ -33,7 +33,7 @@ namespace River.OneMoreAddIn.Commands
 		public override async Task Execute(params object[] args)
 		{
 			using var dialog = new ArrangeContainersDialog();
-			if (dialog.ShowDialog() != System.Windows.Forms.DialogResult.OK)
+			if (dialog.ShowDialog(owner) != System.Windows.Forms.DialogResult.OK)
 			{
 				return;
 			}

--- a/OneMore/Commands/Page/FitGridToTextCommand.cs
+++ b/OneMore/Commands/Page/FitGridToTextCommand.cs
@@ -88,7 +88,7 @@ namespace River.OneMoreAddIn.Commands
 				var height = CalculateLineHeight(style);
 
 				using var dialog = new FitGridToTextDialog(style.FontSize, height);
-				if (dialog.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+				if (dialog.ShowDialog(owner) == System.Windows.Forms.DialogResult.OK)
 				{
 					rule.Attribute("spacing").Value = dialog.Spacing.ToString();
 

--- a/OneMore/Commands/Page/SplitCommand.cs
+++ b/OneMore/Commands/Page/SplitCommand.cs
@@ -51,7 +51,7 @@ namespace River.OneMoreAddIn.Commands
 		public override async Task Execute(params object[] args)
 		{
 			using var dialog = new SplitDialog();
-			if (dialog.ShowDialog() == DialogResult.OK)
+			if (dialog.ShowDialog(owner) == DialogResult.OK)
 			{
 				using (one = new OneNote(out page, out ns, OneNote.PageDetail.All))
 				{

--- a/OneMore/Commands/References/LinkReferencesCommand.cs
+++ b/OneMore/Commands/References/LinkReferencesCommand.cs
@@ -64,7 +64,7 @@ namespace River.OneMoreAddIn.Commands
 			if (!refreshing)
 			{
 				using var dialog = new LinkDialog();
-				if (dialog.ShowDialog() != System.Windows.Forms.DialogResult.OK)
+				if (dialog.ShowDialog(owner) != System.Windows.Forms.DialogResult.OK)
 				{
 					return;
 				}

--- a/OneMore/Commands/References/MapCommand.cs
+++ b/OneMore/Commands/References/MapCommand.cs
@@ -48,7 +48,7 @@ namespace River.OneMoreAddIn.Commands
 		public override async Task Execute(params object[] args)
 		{
 			using var dialog = new MapDialog();
-			if (dialog.ShowDialog() != System.Windows.Forms.DialogResult.OK)
+			if (dialog.ShowDialog(owner) != System.Windows.Forms.DialogResult.OK)
 			{
 				return;
 			}

--- a/OneMore/Commands/References/RefreshPageLinksCommand.cs
+++ b/OneMore/Commands/References/RefreshPageLinksCommand.cs
@@ -34,7 +34,7 @@ namespace River.OneMoreAddIn.Commands
 		public override async Task Execute(params object[] args)
 		{
 			using var dialog = new RefreshPageLinksDialog();
-			if (dialog.ShowDialog() != System.Windows.Forms.DialogResult.OK)
+			if (dialog.ShowDialog(owner) != System.Windows.Forms.DialogResult.OK)
 			{
 				return;
 			}

--- a/OneMore/Commands/Reminders/ImportOutlookTasksCommand.cs
+++ b/OneMore/Commands/Reminders/ImportOutlookTasksCommand.cs
@@ -73,7 +73,7 @@ namespace River.OneMoreAddIn.Commands
 			var folders = outlook.GetTaskHierarchy();
 
 			using var dialog = new ImportOutlookTasksDialog(folders);
-			if (dialog.ShowDialog() != System.Windows.Forms.DialogResult.OK)
+			if (dialog.ShowDialog(owner) != System.Windows.Forms.DialogResult.OK)
 			{
 				return;
 			}

--- a/OneMore/Commands/Reminders/RemindCommand.cs
+++ b/OneMore/Commands/Reminders/RemindCommand.cs
@@ -57,7 +57,7 @@ namespace River.OneMoreAddIn.Commands
 			var reminder = GetReminder(paragraph);
 
 			using var dialog = new RemindDialog(reminder, false);
-			if (dialog.ShowDialog() == DialogResult.OK)
+			if (dialog.ShowDialog(owner) == DialogResult.OK)
 			{
 				if (SetReminder(paragraph, dialog.Reminder))
 				{
@@ -92,7 +92,7 @@ namespace River.OneMoreAddIn.Commands
 
 			using (var dialog = new RemindDialog(reminder, true))
 			{
-				if (dialog.ShowDialog() == DialogResult.OK)
+				if (dialog.ShowDialog(owner) == DialogResult.OK)
 				{
 					if (SetReminder(paragraph, dialog.Reminder))
 					{

--- a/OneMore/Commands/Reminders/ReportRemindersCommand.cs
+++ b/OneMore/Commands/Reminders/ReportRemindersCommand.cs
@@ -87,7 +87,7 @@ namespace River.OneMoreAddIn.Commands
 				else
 				{
 					using var dialog = new ReportRemindersDialog();
-					if (dialog.ShowDialog() != DialogResult.OK)
+					if (dialog.ShowDialog(owner) != DialogResult.OK)
 					{
 						return;
 					}
@@ -262,7 +262,7 @@ namespace River.OneMoreAddIn.Commands
 			DialogResult answer;
 			using (var dialog = new ReportRemindersReuseDialog())
 			{
-				if (dialog.ShowDialog() == DialogResult.Cancel)
+				if (dialog.ShowDialog(owner) == DialogResult.Cancel)
 				{
 					// kind of hacky but...
 					return String.Empty;

--- a/OneMore/Commands/Search/SearchAndReplaceCommand.cs
+++ b/OneMore/Commands/Search/SearchAndReplaceCommand.cs
@@ -37,7 +37,7 @@ namespace River.OneMoreAddIn.Commands
 					dialog.WhatText = text;
 				}
 
-				if (dialog.ShowDialog() != DialogResult.OK)
+				if (dialog.ShowDialog(owner) != DialogResult.OK)
 				{
 					return;
 				}

--- a/OneMore/Commands/Search/TaggingCommand.cs
+++ b/OneMore/Commands/Search/TaggingCommand.cs
@@ -44,7 +44,7 @@ namespace River.OneMoreAddIn.Commands
 				dialog.Tags = parts;
 			}
 
-			if (dialog.ShowDialog() != DialogResult.OK)
+			if (dialog.ShowDialog(owner) != DialogResult.OK)
 			{
 				return;
 			}

--- a/OneMore/Commands/Settings/GeneralSheet.cs
+++ b/OneMore/Commands/Settings/GeneralSheet.cs
@@ -117,7 +117,7 @@ namespace River.OneMoreAddIn.Settings
 			dialog.ShowHelp = true; // stupid, but this is needed to avoid hang
 			dialog.InitialDirectory = GetValidPath(imageViewerBox.Text);
 
-			var result = dialog.ShowDialog();
+			var result = dialog.ShowDialog(/* leave empty */);
 			if (result == DialogResult.OK)
 			{
 				imageViewerBox.Text = dialog.FileName;

--- a/OneMore/Commands/Settings/LinesSheet.cs
+++ b/OneMore/Commands/Settings/LinesSheet.cs
@@ -47,7 +47,7 @@ namespace River.OneMoreAddIn.Settings
 
 			dialog.Color = colorBox.BackColor;
 
-			if (dialog.ShowDialog() == DialogResult.OK)
+			if (dialog.ShowDialog(this) == DialogResult.OK)
 			{
 				colorBox.BackColor = dialog.Color;
 			}

--- a/OneMore/Commands/Settings/SettingsCommand.cs
+++ b/OneMore/Commands/Settings/SettingsCommand.cs
@@ -25,7 +25,7 @@ namespace River.OneMoreAddIn.Commands
 		{
 			using (var dialog = new SettingsDialog(args[0] as IRibbonUI))
 			{
-				dialog.ShowDialog();
+				dialog.ShowDialog(owner);
 
 				if (!dialog.RestartNeeded)
 				{

--- a/OneMore/Commands/Snippets/InsertCalendarCommand.cs
+++ b/OneMore/Commands/Snippets/InsertCalendarCommand.cs
@@ -48,7 +48,7 @@ namespace River.OneMoreAddIn.Commands
 
 			using (var dialog = new InsertCalendarDialog())
 			{
-				if (dialog.ShowDialog() != DialogResult.OK)
+				if (dialog.ShowDialog(owner) != DialogResult.OK)
 				{
 					return;
 				}

--- a/OneMore/Commands/Snippets/InsertCalendarDialog.cs
+++ b/OneMore/Commands/Snippets/InsertCalendarDialog.cs
@@ -86,7 +86,7 @@ namespace River.OneMoreAddIn.Commands
 
 			dialog.Color = shadingBox.BackColor;
 
-			if (dialog.ShowDialog() == DialogResult.OK)
+			if (dialog.ShowDialog(this) == DialogResult.OK)
 			{
 				shadingBox.BackColor = dialog.Color;
 			}

--- a/OneMore/Commands/Snippets/InsertTocCommand.cs
+++ b/OneMore/Commands/Snippets/InsertTocCommand.cs
@@ -58,7 +58,7 @@ namespace River.OneMoreAddIn.Commands
 
 			using (var dialog = new InsertTocDialog())
 			{
-				if (dialog.ShowDialog() == DialogResult.Cancel)
+				if (dialog.ShowDialog(owner) == DialogResult.Cancel)
 				{
 					return;
 				}

--- a/OneMore/Commands/Snippets/ManageSnippetsCommand.cs
+++ b/OneMore/Commands/Snippets/ManageSnippetsCommand.cs
@@ -20,7 +20,7 @@ namespace River.OneMoreAddIn.Commands
 			using (var dialog = new SettingsDialog(args[0] as IRibbonUI))
 			{
 				dialog.ActivateSheet(SettingsDialog.Sheets.Snippets);
-				dialog.ShowDialog();
+				dialog.ShowDialog(owner);
 			}
 
 			await Task.Yield();

--- a/OneMore/Commands/Snippets/SaveSnippetCommand.cs
+++ b/OneMore/Commands/Snippets/SaveSnippetCommand.cs
@@ -41,7 +41,7 @@ namespace River.OneMoreAddIn.Commands
 			}
 
 			using var dialog = new SaveSnippetDialog();
-			if (dialog.ShowDialog() != DialogResult.OK)
+			if (dialog.ShowDialog(owner) != DialogResult.OK)
 			{
 				return;
 			}

--- a/OneMore/Commands/Styles/ChangePageColorCommand.cs
+++ b/OneMore/Commands/Styles/ChangePageColorCommand.cs
@@ -32,7 +32,7 @@ namespace River.OneMoreAddIn.Commands
 			var color = page.GetPageColor(out _, out _);
 
 			using var dialog = new ChangePageColorDialog(color);
-			if (dialog.ShowDialog() != DialogResult.OK)
+			if (dialog.ShowDialog(owner) != DialogResult.OK)
 			{
 				return;
 			}

--- a/OneMore/Commands/Styles/ChangePageColorDialog.cs
+++ b/OneMore/Commands/Styles/ChangePageColorDialog.cs
@@ -102,7 +102,7 @@ namespace River.OneMoreAddIn.Commands
 
 			dialog.Color = colorsBox.CustomColor;
 
-			if (dialog.ShowDialog() == DialogResult.OK)
+			if (dialog.ShowDialog(this) == DialogResult.OK)
 			{
 				colorsBox.SetCustomColor(dialog.Color);
 

--- a/OneMore/Commands/Styles/EditStylesCommand.cs
+++ b/OneMore/Commands/Styles/EditStylesCommand.cs
@@ -35,7 +35,7 @@ namespace River.OneMoreAddIn.Commands
 			var theme = new ThemeProvider().Theme;
 
 			var dialog = new StyleDialog(theme, pageColor);
-			if (dialog.ShowDialog() == DialogResult.OK)
+			if (dialog.ShowDialog(owner) == DialogResult.OK)
 			{
 				ThemeProvider.Save(dialog.Theme);
 				ThemeProvider.RecordTheme(dialog.Theme.Key);

--- a/OneMore/Commands/Styles/NewStyleCommand.cs
+++ b/OneMore/Commands/Styles/NewStyleCommand.cs
@@ -34,7 +34,7 @@ namespace River.OneMoreAddIn.Commands
 			}
 
 			using var dialog = new StyleDialog(style, pageColor);
-			if (dialog.ShowDialog() == DialogResult.OK)
+			if (dialog.ShowDialog(owner) == DialogResult.OK)
 			{
 				if (dialog.Style != null)
 				{

--- a/OneMore/Commands/Styles/StyleDialog.cs
+++ b/OneMore/Commands/Styles/StyleDialog.cs
@@ -576,7 +576,7 @@ namespace River.OneMoreAddIn.Commands
 			{
 				dialog.Color = color;
 
-				if (dialog.ShowDialog() == DialogResult.OK)
+				if (dialog.ShowDialog(this) == DialogResult.OK)
 				{
 					return dialog.Color;
 				}
@@ -759,7 +759,7 @@ namespace River.OneMoreAddIn.Commands
 			var point = PointToScreen(mainTools.Location);
 			dialog.Location = new Point(point.X + dialog.Width, point.Y);
 
-			var result = dialog.ShowDialog();
+			var result = dialog.ShowDialog(this);
 			if (result == DialogResult.OK)
 			{
 				string name = null;
@@ -808,7 +808,7 @@ namespace River.OneMoreAddIn.Commands
 					Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
 			}
 
-			var result = dialog.ShowDialog();
+			var result = dialog.ShowDialog(/* leave empty */);
 			if (result == DialogResult.OK)
 			{
 				theme = new ThemeProvider(dialog.FileName).Theme;
@@ -848,7 +848,7 @@ namespace River.OneMoreAddIn.Commands
 					Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
 			}
 
-			var result = dialog.ShowDialog();
+			var result = dialog.ShowDialog(/* leave empty */);
 			if (result == DialogResult.OK)
 			{
 				var key = Path.GetFileNameWithoutExtension(dialog.FileName);

--- a/OneMore/Commands/Tables/AddFormulaCommand.cs
+++ b/OneMore/Commands/Tables/AddFormulaCommand.cs
@@ -106,7 +106,7 @@ namespace River.OneMoreAddIn.Commands
 				}
 			}
 
-			if (dialog.ShowDialog() != DialogResult.OK)
+			if (dialog.ShowDialog(owner) != DialogResult.OK)
 			{
 				return;
 			}

--- a/OneMore/Commands/Tables/EditTableThemesCommand.cs
+++ b/OneMore/Commands/Tables/EditTableThemesCommand.cs
@@ -26,7 +26,7 @@ namespace River.OneMoreAddIn.Commands
 			var themes = provider.GetUserThemes();
 
 			using var dialog = new EditTableThemesDialog(themes);
-			if (dialog.ShowDialog() == DialogResult.OK)
+			if (dialog.ShowDialog(owner) == DialogResult.OK)
 			{
 				if (dialog.Modified)
 				{

--- a/OneMore/Commands/Tables/EditTableThemesDialog.cs
+++ b/OneMore/Commands/Tables/EditTableThemesDialog.cs
@@ -392,7 +392,7 @@ namespace River.OneMoreAddIn.Commands
 					Color = swatch.Color
 				};
 
-				var result = dialog.ShowDialog();
+				var result = dialog.ShowDialog(this);
 				if (result == DialogResult.Cancel)
 				{
 					return;
@@ -622,7 +622,7 @@ namespace River.OneMoreAddIn.Commands
 
 			dialog.Color = colorfont.Foreground;
 
-			if (dialog.ShowDialog() == DialogResult.OK)
+			if (dialog.ShowDialog(this) == DialogResult.OK)
 			{
 				colorfont.Foreground = dialog.Color;
 			}

--- a/OneMore/Commands/Tables/InsertCellsCommand.cs
+++ b/OneMore/Commands/Tables/InsertCellsCommand.cs
@@ -59,7 +59,7 @@ namespace River.OneMoreAddIn.Commands
 
 			using (var dialog = new InsertCellsDialog())
 			{
-				if (dialog.ShowDialog() != DialogResult.OK)
+				if (dialog.ShowDialog(owner) != DialogResult.OK)
 				{
 					return;
 				}

--- a/OneMore/Commands/Tables/SplitTableCommand.cs
+++ b/OneMore/Commands/Tables/SplitTableCommand.cs
@@ -60,7 +60,7 @@ namespace River.OneMoreAddIn.Commands
 			var fixedCols = false;
 			using (var dialog = new SplitTableDialog())
 			{
-				if (dialog.ShowDialog() != System.Windows.Forms.DialogResult.OK)
+				if (dialog.ShowDialog(owner) != System.Windows.Forms.DialogResult.OK)
 				{
 					return;
 				}

--- a/OneMore/Commands/Tables/TextToTableCommand.cs
+++ b/OneMore/Commands/Tables/TextToTableCommand.cs
@@ -99,7 +99,7 @@ namespace River.OneMoreAddIn.Commands
 
 			dialog.Rows = selections.Count;
 
-			if (dialog.ShowDialog() == System.Windows.Forms.DialogResult.Cancel)
+			if (dialog.ShowDialog(owner) == System.Windows.Forms.DialogResult.Cancel)
 			{
 				return null;
 			}

--- a/OneMore/Commands/Tools/AboutCommand.cs
+++ b/OneMore/Commands/Tools/AboutCommand.cs
@@ -20,7 +20,7 @@ namespace River.OneMoreAddIn.Commands
 		{
 			using (var dialog = new AboutDialog(factory))
 			{
-				dialog.ShowDialog();
+				dialog.ShowDialog(owner);
 			}
 
 			await Task.Yield();

--- a/OneMore/Commands/Tools/CommandPaletteCommand.cs
+++ b/OneMore/Commands/Tools/CommandPaletteCommand.cs
@@ -33,7 +33,7 @@ namespace River.OneMoreAddIn.Commands
 			dialog.RequestData += PopulateCommands;
 			PopulateCommands(dialog, EventArgs.Empty);
 
-			if (dialog.ShowDialog() == DialogResult.OK &&
+			if (dialog.ShowDialog(owner) == DialogResult.OK &&
 				dialog.Index >= 0)
 			{
 				var command = dialog.Recent

--- a/OneMore/Commands/Tools/DiagnosticsCommand.cs
+++ b/OneMore/Commands/Tools/DiagnosticsCommand.cs
@@ -91,7 +91,7 @@ namespace River.OneMoreAddIn.Commands
 				logger.WriteLine(new string('-', 80));
 
 				using var dialog = new DiagnosticsDialog(logger.LogPath);
-				dialog.ShowDialog();
+				dialog.ShowDialog(owner);
 			}
 
 			// turn headers back on

--- a/OneMore/Commands/Tools/ShowXmlCommand.cs
+++ b/OneMore/Commands/Tools/ShowXmlCommand.cs
@@ -22,7 +22,7 @@ namespace River.OneMoreAddIn.Commands
 		public override async Task Execute(params object[] args)
 		{
 			using var dialog = new ShowXmlDialog();
-			dialog.ShowDialog();
+			dialog.ShowDialog(owner);
 
 			await Task.Yield();
 		}

--- a/OneMore/Commands/Tools/UpdateCommand.cs
+++ b/OneMore/Commands/Tools/UpdateCommand.cs
@@ -53,14 +53,14 @@ namespace River.OneMoreAddIn.Commands
 				{
 					// up to date...
 					using var dialog = new UpdateDialog(updater);
-					dialog.ShowDialog();
+					dialog.ShowDialog(owner);
 				}
 
 				return;
 			}
 
 			using var question = new UpdateDialog(updater);
-			if (question.ShowDialog() == DialogResult.OK)
+			if (question.ShowDialog(owner) == DialogResult.OK)
 			{
 				Updated = await updater.Update();
 			}

--- a/OneMore/OneNote.cs
+++ b/OneMore/OneNote.cs
@@ -1350,7 +1350,7 @@ namespace River.OneMoreAddIn
 				logger.Write($" window PID:{processId}, TID:{threadId}");
 				logger.Write($" handle:{window.WindowHandle:x}");
 
-				Native.GetWindowRect((IntPtr)win.WindowHandle, ref bounds);
+				Native.GetWindowRect((IntPtr)window.WindowHandle, ref bounds);
 				logger.WriteLine($" bounds:{bounds.Left},{bounds.Top},{bounds.Right},{bounds.Bottom}");
 			}
 		}

--- a/OneMore/UI/MoreBubbleWindow.cs
+++ b/OneMore/UI/MoreBubbleWindow.cs
@@ -50,7 +50,7 @@ namespace River.OneMoreAddIn.Commands
 		{
 			using var box = new MoreBubbleWindow();
 			box.SetMessage(text);
-			return box.ShowDialog();
+			return box.ShowDialog(/* leave empty */);
 		}
 
 


### PR DESCRIPTION
Fixed root cause of window positioning problem. Command.owner was set once by CommandFactory. If multiple OneNote windows are opened, this bound owner to only the very first window used and if that window was closed, it would leave owner.Handle as undefined. Instead, CommandFactory, reinitializes owner for every new command instantiation.

Restored use of owner parameter in ShowDialog calls to bind windows to the currently active OneNote window. This solves the z-order problem.