### PR TITLE
Fix broken serialization

### DIFF
--- a/OneMore/Commands/Reminders/ReminderSerializer.cs
+++ b/OneMore/Commands/Reminders/ReminderSerializer.cs
@@ -194,9 +194,13 @@ namespace River.OneMoreAddIn.Commands
 					new JsonSerializerSettings { DateFormatString = JDateFormat });
 
 				using var stream = new MemoryStream();
-				using var zipper = new GZipStream(stream, CompressionMode.Compress);
-				var bytes = Encoding.UTF8.GetBytes(json);
-				zipper.Write(bytes, 0, bytes.Length);
+
+				// do not simplify this statement to ensure stream is Flushed and Closed
+				using (var zipper = new GZipStream(stream, CompressionMode.Compress))
+				{
+					var bytes = Encoding.UTF8.GetBytes(json);
+					zipper.Write(bytes, 0, bytes.Length);
+				}
 
 				return Convert.ToBase64String(stream.ToArray());
 			}


### PR DESCRIPTION
## Enhancement or Defect Addressed by This PR
Serialization of Reminders was broken when simplifying `using` statements. This misses the necessary Flush and Close calls that are done implicity in a `using { }` block, which updates the underlying stream. The result was truncated data stored on the page which could not be de-serialized.

## Description of Proposed Changes
Reverted the simplified `using` statement back to a `using { }` block
