### PR TITLE
848 focus paste

### DIFF
--- a/OneMore/Commands/File/ImportDialog.Designer.cs
+++ b/OneMore/Commands/File/ImportDialog.Designer.cs
@@ -43,6 +43,7 @@
 			this.powerSectionButton = new System.Windows.Forms.RadioButton();
 			this.introLabel = new System.Windows.Forms.Label();
 			this.notInstalledLabel = new System.Windows.Forms.Label();
+			this.errorLabel = new System.Windows.Forms.Label();
 			this.wordGroup.SuspendLayout();
 			this.powerGroup.SuspendLayout();
 			this.SuspendLayout();
@@ -195,12 +196,24 @@
 			// notInstalledLabel
 			// 
 			this.notInstalledLabel.AutoSize = true;
+			this.notInstalledLabel.ForeColor = System.Drawing.Color.Firebrick;
 			this.notInstalledLabel.Location = new System.Drawing.Point(27, 113);
 			this.notInstalledLabel.Name = "notInstalledLabel";
 			this.notInstalledLabel.Size = new System.Drawing.Size(306, 20);
 			this.notInstalledLabel.TabIndex = 10;
 			this.notInstalledLabel.Text = "The required Office product is not installed";
 			this.notInstalledLabel.Visible = false;
+			// 
+			// errorLabel
+			// 
+			this.errorLabel.AutoSize = true;
+			this.errorLabel.ForeColor = System.Drawing.Color.Firebrick;
+			this.errorLabel.Location = new System.Drawing.Point(27, 270);
+			this.errorLabel.Name = "errorLabel";
+			this.errorLabel.Size = new System.Drawing.Size(114, 20);
+			this.errorLabel.TabIndex = 11;
+			this.errorLabel.Text = "Path not found";
+			this.errorLabel.Visible = false;
 			// 
 			// ImportDialog
 			// 
@@ -209,6 +222,7 @@
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
 			this.CancelButton = this.cancelButton;
 			this.ClientSize = new System.Drawing.Size(579, 317);
+			this.Controls.Add(this.errorLabel);
 			this.Controls.Add(this.notInstalledLabel);
 			this.Controls.Add(this.introLabel);
 			this.Controls.Add(this.wordGroup);
@@ -252,5 +266,6 @@
 		private System.Windows.Forms.RadioButton powerSectionButton;
 		private System.Windows.Forms.Label introLabel;
 		private System.Windows.Forms.Label notInstalledLabel;
+		private System.Windows.Forms.Label errorLabel;
 	}
 }

--- a/OneMore/Commands/Settings/GeneralSheet.cs
+++ b/OneMore/Commands/Settings/GeneralSheet.cs
@@ -157,7 +157,7 @@ namespace River.OneMoreAddIn.Settings
 			var path = imageViewerBox.Text.Trim();
 			if (!string.IsNullOrEmpty(path) && (path != "mspaint") && !File.Exists(path))
 			{
-				errorProvider1.SetError(imageViewerButton, Resx.GeneralSheet_pathNotFound);
+				errorProvider1.SetError(imageViewerButton, Resx.phrase_PathNotFound);
 			}
 			else
 			{

--- a/OneMore/OneMore.csproj
+++ b/OneMore/OneMore.csproj
@@ -1360,7 +1360,6 @@
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <SubType>Designer</SubType>
-      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
     <EmbeddedResource Include="Commands\Tools\ShowXmlDialog.resx">
       <DependentUpon>ShowXmlDialog.cs</DependentUpon>

--- a/OneMore/Properties/Resources.Designer.cs
+++ b/OneMore/Properties/Resources.Designer.cs
@@ -2984,15 +2984,6 @@ namespace River.OneMoreAddIn.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Path not found.
-        /// </summary>
-        internal static string GeneralSheet_pathNotFound {
-            get {
-                return ResourceManager.GetString("GeneralSheet_pathNotFound", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to General Options.
         /// </summary>
         internal static string GeneralSheet_Title {
@@ -4398,6 +4389,15 @@ namespace River.OneMoreAddIn.Properties {
             get {
                 object obj = ResourceManager.GetObject("Pencil", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Path not found.
+        /// </summary>
+        internal static string phrase_PathNotFound {
+            get {
+                return ResourceManager.GetString("phrase_PathNotFound", resourceCulture);
             }
         }
         

--- a/OneMore/Properties/Resources.ar-SA.resx
+++ b/OneMore/Properties/Resources.ar-SA.resx
@@ -1304,9 +1304,6 @@
     <value>لغة العرض (يجب إعادة تشغيل OneNote)</value>
     <comment>label</comment>
   </data>
-  <data name="GeneralSheet_pathNotFound" xml:space="preserve">
-    <value>المسار مفقود</value>
-  </data>
   <data name="GeneralSheet_Title" xml:space="preserve">
     <value>خيارات عامة</value>
     <comment>settings sheet</comment>
@@ -4664,5 +4661,8 @@ ISO-code then comma then language name</comment>
   <data name="ribCopyAcrossButton_Screentip" xml:space="preserve">
     <value>نسخ المحتوى عبر الصفوف المحددة</value>
     <comment>ribbon table</comment>
+  </data>
+  <data name="phrase_PathNotFound" xml:space="preserve">
+    <value>المسار مفقود</value>
   </data>
 </root>

--- a/OneMore/Properties/Resources.de-DE.resx
+++ b/OneMore/Properties/Resources.de-DE.resx
@@ -1299,9 +1299,6 @@ Symbole: PI, E</value>
     <value>Anzeigesprache (OneNote muss neu gestartet werden)</value>
     <comment>label</comment>
   </data>
-  <data name="GeneralSheet_pathNotFound" xml:space="preserve">
-    <value>Pfad nicht gefunden</value>
-  </data>
   <data name="GeneralSheet_Title" xml:space="preserve">
     <value>Allgemeine Optionen</value>
     <comment>settings sheet</comment>
@@ -4651,5 +4648,8 @@ In diesem Abschnitt</value>
   <data name="ribCopyAcrossButton_Screentip" xml:space="preserve">
     <value>Kopieren Sie Inhalte über die ausgewählten Zeilen</value>
     <comment>ribbon table</comment>
+  </data>
+  <data name="phrase_PathNotFound" xml:space="preserve">
+    <value>Pfad nicht gefunden</value>
   </data>
 </root>

--- a/OneMore/Properties/Resources.es-ES.resx
+++ b/OneMore/Properties/Resources.es-ES.resx
@@ -1304,9 +1304,6 @@ Símbolos: PI, E</value>
     <value>Idioma de visualización (debe reiniciar OneNote)</value>
     <comment>label</comment>
   </data>
-  <data name="GeneralSheet_pathNotFound" xml:space="preserve">
-    <value>Camino no encontrado</value>
-  </data>
   <data name="GeneralSheet_Title" xml:space="preserve">
     <value>Opciones generales</value>
     <comment>settings sheet</comment>
@@ -4664,5 +4661,8 @@ En esta sección</value>
   <data name="ribCopyAcrossButton_Screentip" xml:space="preserve">
     <value>Copiar contenido en las filas seleccionadas</value>
     <comment>ribbon table</comment>
+  </data>
+  <data name="phrase_PathNotFound" xml:space="preserve">
+    <value>Camino no encontrado</value>
   </data>
 </root>

--- a/OneMore/Properties/Resources.fr-FR.resx
+++ b/OneMore/Properties/Resources.fr-FR.resx
@@ -1301,9 +1301,6 @@ Symboles : PI, E</value>
     <value>Langue d'affichage (doit redémarrer OneNote)</value>
     <comment>label</comment>
   </data>
-  <data name="GeneralSheet_pathNotFound" xml:space="preserve">
-    <value>Chemin non trouvé</value>
-  </data>
   <data name="GeneralSheet_Title" xml:space="preserve">
     <value>Options générales</value>
     <comment>settings sheet</comment>
@@ -4658,5 +4655,8 @@ Dans cette section</value>
   <data name="ribCopyAcrossButton_Screentip" xml:space="preserve">
     <value>Copier le contenu sur les lignes sélectionnées</value>
     <comment>ribbon table</comment>
+  </data>
+  <data name="phrase_PathNotFound" xml:space="preserve">
+    <value>Chemin introuvable</value>
   </data>
 </root>

--- a/OneMore/Properties/Resources.he-IL.resx
+++ b/OneMore/Properties/Resources.he-IL.resx
@@ -1354,9 +1354,6 @@ Total Row Font
     <value>שפת תצוגה (חייב להפעיל מחדש את OneNote)</value>
     <comment>label</comment>
   </data>
-  <data name="GeneralSheet_pathNotFound" xml:space="preserve">
-    <value>נתיב לא נמצא</value>
-  </data>
   <data name="GeneralSheet_Title" xml:space="preserve">
     <value>אפשרויות כלליות</value>
     <comment>settings sheet</comment>
@@ -4759,5 +4756,8 @@ ISO-code then comma then language name</comment>
   <data name="ribCopyAcrossButton_Screentip" xml:space="preserve">
     <value>העתק תוכן על פני השורות שנבחרו</value>
     <comment>ribbon table</comment>
+  </data>
+  <data name="phrase_PathNotFound" xml:space="preserve">
+    <value>נתיב לא נמצא</value>
   </data>
 </root>

--- a/OneMore/Properties/Resources.nl-NL.resx
+++ b/OneMore/Properties/Resources.nl-NL.resx
@@ -1305,9 +1305,6 @@ Symbolen: PI, E</value>
     <value>Weergavetaal (moet OneNote opnieuw starten)</value>
     <comment>label</comment>
   </data>
-  <data name="GeneralSheet_pathNotFound" xml:space="preserve">
-    <value>Pad niet gevonden</value>
-  </data>
   <data name="GeneralSheet_Title" xml:space="preserve">
     <value>Algemene opties</value>
     <comment>settings sheet</comment>
@@ -4664,5 +4661,8 @@ In deze sectie</value>
   <data name="ribCopyAcrossButton_Screentip" xml:space="preserve">
     <value>Kopieer inhoud over de geselecteerde rijen</value>
     <comment>ribbon table</comment>
+  </data>
+  <data name="phrase_PathNotFound" xml:space="preserve">
+    <value>Pad niet gevonden</value>
   </data>
 </root>

--- a/OneMore/Properties/Resources.pl-PL.resx
+++ b/OneMore/Properties/Resources.pl-PL.resx
@@ -1328,9 +1328,6 @@ Symbole: PI, E</value>
     <value>Język wyświetlacza (musi ponownie uruchomić OneNote)</value>
     <comment>label</comment>
   </data>
-  <data name="GeneralSheet_pathNotFound" xml:space="preserve">
-    <value>Droga nie znaleziona</value>
-  </data>
   <data name="GeneralSheet_Title" xml:space="preserve">
     <value>Ogólne opcje</value>
     <comment>settings sheet</comment>
@@ -4717,5 +4714,8 @@ W tej sekcji</value>
   <data name="ribCopyAcrossButton_Screentip" xml:space="preserve">
     <value>Skopiuj treść w wybranych wierszach</value>
     <comment>ribbon table</comment>
+  </data>
+  <data name="phrase_PathNotFound" xml:space="preserve">
+    <value>Droga nie znaleziona</value>
   </data>
 </root>

--- a/OneMore/Properties/Resources.pt-BR.resx
+++ b/OneMore/Properties/Resources.pt-BR.resx
@@ -1305,9 +1305,6 @@ Símbolos: PI, E</value>
     <value>Idioma de exibição (deve reiniciar o OneNote)</value>
     <comment>label</comment>
   </data>
-  <data name="GeneralSheet_pathNotFound" xml:space="preserve">
-    <value>Caminho não encontrado</value>
-  </data>
   <data name="GeneralSheet_Title" xml:space="preserve">
     <value>Opções gerais</value>
     <comment>settings sheet</comment>
@@ -4664,5 +4661,8 @@ Nesta secção</value>
   <data name="ribCopyAcrossButton_Screentip" xml:space="preserve">
     <value>Copie o conteúdo nas linhas selecionadas</value>
     <comment>ribbon table</comment>
+  </data>
+  <data name="phrase_PathNotFound" xml:space="preserve">
+    <value>Caminho não encontrado</value>
   </data>
 </root>

--- a/OneMore/Properties/Resources.resx
+++ b/OneMore/Properties/Resources.resx
@@ -1366,9 +1366,6 @@ Symbols: PI, E</value>
     <value>Display language (must restart OneNote)</value>
     <comment>label</comment>
   </data>
-  <data name="GeneralSheet_pathNotFound" xml:space="preserve">
-    <value>Path not found</value>
-  </data>
   <data name="GeneralSheet_Title" xml:space="preserve">
     <value>General Options</value>
     <comment>settings sheet</comment>
@@ -1970,6 +1967,9 @@ Deferred</value>
   </data>
   <data name="Pencil" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>emoji\pencil.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="phrase_PathNotFound" xml:space="preserve">
+    <value>Path not found</value>
   </data>
   <data name="Plugin_InvalidSchema" xml:space="preserve">
     <value>Invalid XML detected. Check log file for details</value>

--- a/OneMore/Properties/Resources.zh-CN.resx
+++ b/OneMore/Properties/Resources.zh-CN.resx
@@ -1303,9 +1303,6 @@ OneNote 文件 (*.one)</value>
     <value>显示语言（必须重启 OneNote）</value>
     <comment>label</comment>
   </data>
-  <data name="GeneralSheet_pathNotFound" xml:space="preserve">
-    <value>找不到路径</value>
-  </data>
   <data name="GeneralSheet_Title" xml:space="preserve">
     <value>常规选项</value>
     <comment>settings sheet</comment>
@@ -4648,5 +4645,8 @@ ISO-code then comma then language name</comment>
   <data name="ribCopyAcrossButton_Screentip" xml:space="preserve">
     <value>通过选定的行复制内容</value>
     <comment>ribbon table</comment>
+  </data>
+  <data name="phrase_PathNotFound" xml:space="preserve">
+    <value>找不到路径</value>
   </data>
 </root>


### PR DESCRIPTION
As each page is created in a batch import, force focus back to the OneNote window to give the emitted Ctrl+V paste operation a valid target, instead of the progress dialog.

Also updated the import dialog to require that the source path describes files that exist.
