### PR TITLE
788 fix hotkeys after alt tab

### DIFF
--- a/OneMore/Helpers/Hotkeys/HotkeyManager.cs
+++ b/OneMore/Helpers/Hotkeys/HotkeyManager.cs
@@ -9,6 +9,7 @@ namespace River.OneMoreAddIn
 {
 	using System;
 	using System.Collections.Generic;
+	using System.Diagnostics;
 	using System.Linq;
 	using System.Runtime.InteropServices;
 	using System.Threading;
@@ -39,11 +40,15 @@ namespace River.OneMoreAddIn
 
 		private static readonly List<Hotkey> registeredKeys = new();
 		private static readonly ManualResetEvent resetEvent = new(false);
-		private static volatile MessageWindow window;
-		private static volatile IntPtr handle;
-		private static uint threadId;
+
+		private static volatile MessageWindow mwindow;	// message window
+		private static volatile IntPtr mhandle;			// message window handle
+		private static GCHandle mroot;                  // rooted handle to message window
+
+		private static uint oprocessId;					// onenote process ID
+		private static uint dprocessId;					// onemore dllhost process ID
+
 		private static bool registered = false;
-		private static GCHandle gch;
 
 
 		/// <summary>
@@ -58,7 +63,8 @@ namespace River.OneMoreAddIn
 		public static void Initialize()
 		{
 			using var one = new OneNote();
-			threadId = Native.GetWindowThreadProcessId(one.WindowHandle, out _);
+			Native.GetWindowThreadProcessId(one.WindowHandle, out oprocessId);
+			dprocessId = (uint)Process.GetCurrentProcess().Id;
 
 			var mthread = new Thread(delegate () { Application.Run(new MessageWindow()); })
 			{
@@ -81,9 +87,9 @@ namespace River.OneMoreAddIn
 
 			var modifiers = hotkey.HotModifiers | (uint)HotModifier.NoRepeat;
 
-			window.Invoke(
+			mwindow.Invoke(
 				new RegisterHotkeyDelegate(Register),
-				handle, hotkey.Id, modifiers, hotkey.Key);
+				mhandle, hotkey.Id, modifiers, hotkey.Key);
 
 			hotkey.Action = action;
 			hotkey.HotModifiers = modifiers;
@@ -107,12 +113,12 @@ namespace River.OneMoreAddIn
 		public static void Unregister()
 		{
 			registeredKeys.ForEach(k =>
-				window.Invoke(new UnRegisterHotkeyDelegate(Unregister), handle, k.Id));
+				mwindow.Invoke(new UnRegisterHotkeyDelegate(Unregister), mhandle, k.Id));
 
 			// may not be allocated if the add-in startup has failed
-			if (gch.IsAllocated)
+			if (mroot.IsAllocated)
 			{
-				gch.Free();
+				mroot.Free();
 			}
 		}
 
@@ -120,7 +126,7 @@ namespace River.OneMoreAddIn
 		// runs as a delegated routine within the context of MessageWindow
 		private static void Unregister(IntPtr hwnd, int id)
 		{
-			Native.UnregisterHotKey(handle, id);
+			Native.UnregisterHotKey(mhandle, id);
 		}
 
 
@@ -157,16 +163,16 @@ namespace River.OneMoreAddIn
 
 			public MessageWindow()
 			{
-				window = this;
-				handle = Handle;
+				mwindow = this;
+				mhandle = Handle;
 
 				// thread of MessageWindow would be a separate dllhost.exe
 				// process started by the OneNote process (with SysWOW64 in its command line)
-				msgThreadId = Native.GetWindowThreadProcessId(handle, out _);
+				msgThreadId = Native.GetWindowThreadProcessId(mhandle, out _);
 
 				// maintain a ref so GC doesn't remove it and cause exceptions
 				var evDelegate = new Native.WinEventDelegate(WinEventProc);
-				gch = GCHandle.Alloc(evDelegate);
+				mroot = GCHandle.Alloc(evDelegate);
 
 				// set up event hook to monitor switching application
 				Native.SetWinEventHook(
@@ -184,7 +190,8 @@ namespace River.OneMoreAddIn
 				IntPtr hWinEventHook, uint eventType, IntPtr hwnd,
 				int idObject, int idChild, uint dwEventThread, uint dwmsEventTime)
 			{
-				//Logger.Current.WriteLine($"hotkey event:{eventType} thread:{dwEventThread}");
+				Native.GetWindowThreadProcessId(Native.GetForegroundWindow(), out var pid);
+				//Logger.Current.WriteLine($"hotkey event:{eventType} pid:{pid} thread:{dwEventThread}");
 
 				if (eventType == Native.EVENT_SYSTEM_FOREGROUND ||
 					eventType == Native.EVENT_SYSTEM_MINIMIZESTART ||
@@ -196,13 +203,13 @@ namespace River.OneMoreAddIn
 					// OneNote.exe from another app; while msgThreadId will be current when
 					// opening a OneMore dialog such as "Search and Replace"
 
-					if ((dwEventThread == threadId) || (dwEventThread == msgThreadId))
+					if (pid == oprocessId || pid == dprocessId)
 					{
 						if (!registered && registeredKeys.Count > 0)
 						{
 							//Logger.Current.WriteLine("hotkey re-registering");
 							registeredKeys.ForEach(k =>
-								Native.RegisterHotKey(handle, k.Id, k.HotModifiers, k.Key));
+								Native.RegisterHotKey(mhandle, k.Id, k.HotModifiers, k.Key));
 
 							registered = true;
 						}
@@ -213,7 +220,7 @@ namespace River.OneMoreAddIn
 						{
 							//Logger.Current.WriteLine("hotkey uregistering");
 							registeredKeys.ForEach(k =>
-								Native.UnregisterHotKey(handle, k.Id));
+								Native.UnregisterHotKey(mhandle, k.Id));
 
 							registered = false;
 						}
@@ -227,8 +234,8 @@ namespace River.OneMoreAddIn
 				if (m.Msg == Native.WM_HOTKEY)
 				{
 					// check if this is the main OneNote.exe thread and not a dllhost.exe thread
-					var tid = Native.GetWindowThreadProcessId(Native.GetForegroundWindow(), out _);
-					if (tid == threadId)
+					Native.GetWindowThreadProcessId(Native.GetForegroundWindow(), out var pid);
+					if (pid == oprocessId)
 					{
 						OnHotKeyPressed(new HotkeyEventArgs(m.LParam));
 					}

--- a/OneMore/Helpers/Hotkeys/HotkeyManager.cs
+++ b/OneMore/Helpers/Hotkeys/HotkeyManager.cs
@@ -9,6 +9,7 @@ namespace River.OneMoreAddIn
 {
 	using System;
 	using System.Collections.Generic;
+	using System.Diagnostics;
 	using System.Linq;
 	using System.Runtime.InteropServices;
 	using System.Threading;
@@ -39,11 +40,15 @@ namespace River.OneMoreAddIn
 
 		private static readonly List<Hotkey> registeredKeys = new();
 		private static readonly ManualResetEvent resetEvent = new(false);
-		private static volatile MessageWindow window;
-		private static volatile IntPtr handle;
-		private static uint threadId;
+
+		private static volatile MessageWindow mwindow;  // message window
+		private static volatile IntPtr mhandle;         // message window handle
+		private static GCHandle mroot;                  // rooted handle to message window
+
+		private static uint oprocessId;                 // onenote process ID
+		private static uint dprocessId;                 // onemore dllhost process ID
+
 		private static bool registered = false;
-		private static GCHandle gch;
 
 
 		/// <summary>
@@ -58,7 +63,8 @@ namespace River.OneMoreAddIn
 		public static void Initialize()
 		{
 			using var one = new OneNote();
-			threadId = Native.GetWindowThreadProcessId(one.WindowHandle, out _);
+			Native.GetWindowThreadProcessId(one.WindowHandle, out oprocessId);
+			dprocessId = (uint)Process.GetCurrentProcess().Id;
 
 			var mthread = new Thread(delegate () { Application.Run(new MessageWindow()); })
 			{
@@ -81,9 +87,9 @@ namespace River.OneMoreAddIn
 
 			var modifiers = hotkey.HotModifiers | (uint)HotModifier.NoRepeat;
 
-			window.Invoke(
+			mwindow.Invoke(
 				new RegisterHotkeyDelegate(Register),
-				handle, hotkey.Id, modifiers, hotkey.Key);
+				mhandle, hotkey.Id, modifiers, hotkey.Key);
 
 			hotkey.Action = action;
 			hotkey.HotModifiers = modifiers;
@@ -107,12 +113,12 @@ namespace River.OneMoreAddIn
 		public static void Unregister()
 		{
 			registeredKeys.ForEach(k =>
-				window.Invoke(new UnRegisterHotkeyDelegate(Unregister), handle, k.Id));
+				mwindow.Invoke(new UnRegisterHotkeyDelegate(Unregister), mhandle, k.Id));
 
 			// may not be allocated if the add-in startup has failed
-			if (gch.IsAllocated)
+			if (mroot.IsAllocated)
 			{
-				gch.Free();
+				mroot.Free();
 			}
 		}
 
@@ -120,7 +126,7 @@ namespace River.OneMoreAddIn
 		// runs as a delegated routine within the context of MessageWindow
 		private static void Unregister(IntPtr hwnd, int id)
 		{
-			Native.UnregisterHotKey(handle, id);
+			Native.UnregisterHotKey(mhandle, id);
 		}
 
 
@@ -130,9 +136,9 @@ namespace River.OneMoreAddIn
 			//Logger.Current.WriteLine($"keypress key:{e.Key} mods:{e.Modifiers}");
 
 			var key = registeredKeys
-				.FirstOrDefault(k => 
-					k.Key == (uint)e.Key && 
-					k.HotModifiers == (uint)(e.HotModifiers|HotModifier.NoRepeat));
+				.FirstOrDefault(k =>
+					k.Key == (uint)e.Key &&
+					k.HotModifiers == (uint)(e.HotModifiers | HotModifier.NoRepeat));
 
 			if (key != null)
 			{
@@ -157,16 +163,16 @@ namespace River.OneMoreAddIn
 
 			public MessageWindow()
 			{
-				window = this;
-				handle = Handle;
+				mwindow = this;
+				mhandle = Handle;
 
 				// thread of MessageWindow would be a separate dllhost.exe
 				// process started by the OneNote process (with SysWOW64 in its command line)
-				msgThreadId = Native.GetWindowThreadProcessId(handle, out _);
+				msgThreadId = Native.GetWindowThreadProcessId(mhandle, out _);
 
 				// maintain a ref so GC doesn't remove it and cause exceptions
 				var evDelegate = new Native.WinEventDelegate(WinEventProc);
-				gch = GCHandle.Alloc(evDelegate);
+				mroot = GCHandle.Alloc(evDelegate);
 
 				// set up event hook to monitor switching application
 				Native.SetWinEventHook(
@@ -184,7 +190,8 @@ namespace River.OneMoreAddIn
 				IntPtr hWinEventHook, uint eventType, IntPtr hwnd,
 				int idObject, int idChild, uint dwEventThread, uint dwmsEventTime)
 			{
-				//Logger.Current.WriteLine($"hotkey event:{eventType} thread:{dwEventThread}");
+				Native.GetWindowThreadProcessId(Native.GetForegroundWindow(), out var pid);
+				//Logger.Current.WriteLine($"hotkey event:{eventType} pid:{pid} thread:{dwEventThread}");
 
 				if (eventType == Native.EVENT_SYSTEM_FOREGROUND ||
 					eventType == Native.EVENT_SYSTEM_MINIMIZESTART ||
@@ -196,13 +203,13 @@ namespace River.OneMoreAddIn
 					// OneNote.exe from another app; while msgThreadId will be current when
 					// opening a OneMore dialog such as "Search and Replace"
 
-					if ((dwEventThread == threadId) || (dwEventThread == msgThreadId))
+					if (pid == oprocessId || pid == dprocessId)
 					{
 						if (!registered && registeredKeys.Count > 0)
 						{
 							//Logger.Current.WriteLine("hotkey re-registering");
 							registeredKeys.ForEach(k =>
-								Native.RegisterHotKey(handle, k.Id, k.HotModifiers, k.Key));
+								Native.RegisterHotKey(mhandle, k.Id, k.HotModifiers, k.Key));
 
 							registered = true;
 						}
@@ -213,7 +220,7 @@ namespace River.OneMoreAddIn
 						{
 							//Logger.Current.WriteLine("hotkey uregistering");
 							registeredKeys.ForEach(k =>
-								Native.UnregisterHotKey(handle, k.Id));
+								Native.UnregisterHotKey(mhandle, k.Id));
 
 							registered = false;
 						}
@@ -227,8 +234,8 @@ namespace River.OneMoreAddIn
 				if (m.Msg == Native.WM_HOTKEY)
 				{
 					// check if this is the main OneNote.exe thread and not a dllhost.exe thread
-					var tid = Native.GetWindowThreadProcessId(Native.GetForegroundWindow(), out _);
-					if (tid == threadId)
+					Native.GetWindowThreadProcessId(Native.GetForegroundWindow(), out var pid);
+					if (pid == oprocessId)
 					{
 						OnHotKeyPressed(new HotkeyEventArgs(m.LParam));
 					}


### PR DESCRIPTION
#788 

Fixes an issue where hotkeys were no longer registered after returning to OneNote using Alt+Tab. The workaround was to open the OneMore menu to reactivate hotkeys. 