### PR TITLE
Replace Add Title Emoji with Insert Emoji

### DIFF
--- a/OneMore/AddInCommands.cs
+++ b/OneMore/AddInCommands.cs
@@ -51,7 +51,7 @@ namespace River.OneMoreAddIn
 			=> await factory.Run<AddFormulaCommand>();
 
 
-		[Command("ribEmojiButton_Label", Keys.None, "ribPageMenu")]
+		[Command("ribEmojiButton_Label", Keys.None, "ribEditMenu")]
 		public async Task EmojiCmd(IRibbonControl control)
 			=> await factory.Run<EmojiCommand>();
 

--- a/OneMore/Commands/Page/EmojiDialog.Designer.cs
+++ b/OneMore/Commands/Page/EmojiDialog.Designer.cs
@@ -78,7 +78,7 @@
 			this.introLabel.Name = "introLabel";
 			this.introLabel.Size = new System.Drawing.Size(328, 20);
 			this.introLabel.TabIndex = 4;
-			this.introLabel.Text = "Select one or more emojis to add to page title";
+			this.introLabel.Text = "Select one or more emojis to insert";
 			// 
 			// EmojiDialog
 			// 
@@ -98,7 +98,7 @@
 			this.Name = "EmojiDialog";
 			this.ShowInTaskbar = false;
 			this.StartPosition = System.Windows.Forms.FormStartPosition.Manual;
-			this.Text = "Page Title Emojis";
+			this.Text = "Insert Emojis";
 			this.ResumeLayout(false);
 			this.PerformLayout();
 

--- a/OneMore/Properties/Resources.Designer.cs
+++ b/OneMore/Properties/Resources.Designer.cs
@@ -2041,7 +2041,7 @@ namespace River.OneMoreAddIn.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Select on or more emojis to add to page title.
+        ///   Looks up a localized string similar to Select on or more emojis to insert.
         /// </summary>
         internal static string EmojiDialog_introLabel_Text {
             get {
@@ -2050,7 +2050,7 @@ namespace River.OneMoreAddIn.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to TItle Emojis.
+        ///   Looks up a localized string similar to Insert Emojis.
         /// </summary>
         internal static string EmojiDialog_Text {
             get {
@@ -6758,7 +6758,7 @@ namespace River.OneMoreAddIn.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Add Page Title Emoji.
+        ///   Looks up a localized string similar to Insert Emoji.
         /// </summary>
         internal static string ribEmojiButton_Label {
             get {
@@ -6767,7 +6767,7 @@ namespace River.OneMoreAddIn.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Prepent page title with emojis.
+        ///   Looks up a localized string similar to Insert one or more emojis.
         /// </summary>
         internal static string ribEmojiButton_Screentip {
             get {

--- a/OneMore/Properties/Resources.ar-SA.resx
+++ b/OneMore/Properties/Resources.ar-SA.resx
@@ -871,11 +871,11 @@
     <comment>emoji</comment>
   </data>
   <data name="EmojiDialog.Text" xml:space="preserve">
-    <value>TItle Emojis</value>
+    <value>أدخل الرموز التعبيرية</value>
     <comment>dialog title</comment>
   </data>
   <data name="EmojiDialog_introLabel.Text" xml:space="preserve">
-    <value>حدد أو أكثر من الرموز التعبيرية لإضافتها إلى عنوان الصفحة</value>
+    <value>حدد أو أكثر من الرموز التعبيرية لإدراجها</value>
     <comment>instructions</comment>
   </data>
   <data name="Error_BodyContext" xml:space="preserve">
@@ -2781,12 +2781,12 @@ ISO-code then comma then language name</comment>
     <comment>ribbon item screentip</comment>
   </data>
   <data name="ribEmojiButton_Label" xml:space="preserve">
-    <value>إضافة رمز تعبيري لعنوان الصفحة</value>
-    <comment>Ribbon OneMore menu item, Extras... EDIT</comment>
+    <value>أدخل رمز تعبيري</value>
+    <comment>ribbon edit</comment>
   </data>
   <data name="ribEmojiButton_Screentip" xml:space="preserve">
-    <value>قبل عنوان الصفحة مع الرموز التعبيرية</value>
-    <comment>ribbon page</comment>
+    <value>أدخل واحدًا أو أكثر من الرموز التعبيرية</value>
+    <comment>ribbon edit</comment>
   </data>
   <data name="ribEnableSpellCheckButton_Label" xml:space="preserve">
     <value>تمكين التدقيق الإملائي</value>

--- a/OneMore/Properties/Resources.de-DE.resx
+++ b/OneMore/Properties/Resources.de-DE.resx
@@ -870,11 +870,11 @@ Schriftart der letzten Spalte</value>
     <comment>emoji</comment>
   </data>
   <data name="EmojiDialog.Text" xml:space="preserve">
-    <value>Titel-Emojis</value>
+    <value>Emojis einfügen</value>
     <comment>dialog title</comment>
   </data>
   <data name="EmojiDialog_introLabel.Text" xml:space="preserve">
-    <value>Wählen Sie ein oder mehrere Emojis aus, um sie dem Seitentitel hinzuzufügen</value>
+    <value>Wählen Sie ein oder mehrere Emojis zum Einfügen aus</value>
     <comment>instructions</comment>
   </data>
   <data name="Error_BodyContext" xml:space="preserve">
@@ -2785,12 +2785,12 @@ Polaroid</value>
     <comment>ribbon item screentip</comment>
   </data>
   <data name="ribEmojiButton_Label" xml:space="preserve">
-    <value>Seitentitel Emoji hinzufügen</value>
-    <comment>Ribbon OneMore menu item, Extras... EDIT</comment>
+    <value>Emoji einfügen</value>
+    <comment>ribbon edit</comment>
   </data>
   <data name="ribEmojiButton_Screentip" xml:space="preserve">
-    <value>Seitentitel mit Emojis voranstellen</value>
-    <comment>ribbon page</comment>
+    <value>Fügen Sie ein oder mehrere Emojis ein</value>
+    <comment>ribbon edit</comment>
   </data>
   <data name="ribEnableSpellCheckButton_Label" xml:space="preserve">
     <value>Rechtschreibprüfung aktivieren</value>

--- a/OneMore/Properties/Resources.es-ES.resx
+++ b/OneMore/Properties/Resources.es-ES.resx
@@ -871,11 +871,11 @@ Fuente de la última columna</value>
     <comment>emoji</comment>
   </data>
   <data name="EmojiDialog.Text" xml:space="preserve">
-    <value>Emojis de títulos</value>
+    <value>Insertar emojis</value>
     <comment>dialog title</comment>
   </data>
   <data name="EmojiDialog_introLabel.Text" xml:space="preserve">
-    <value>Seleccione uno o más emojis para agregar al título de la página</value>
+    <value>Seleccione uno o más emojis para insertar</value>
     <comment>instructions</comment>
   </data>
   <data name="Error_BodyContext" xml:space="preserve">
@@ -2781,12 +2781,12 @@ polaroid</value>
     <comment>ribbon item screentip</comment>
   </data>
   <data name="ribEmojiButton_Label" xml:space="preserve">
-    <value>Añadir emoji de título de página</value>
-    <comment>Ribbon OneMore menu item, Extras... EDIT</comment>
+    <value>Insertar emojis</value>
+    <comment>ribbon edit</comment>
   </data>
   <data name="ribEmojiButton_Screentip" xml:space="preserve">
-    <value>Título de página preestablecido con emojis</value>
-    <comment>ribbon page</comment>
+    <value>Inserta uno o más emojis</value>
+    <comment>ribbon edit</comment>
   </data>
   <data name="ribEnableSpellCheckButton_Label" xml:space="preserve">
     <value>Habilitar el corrector ortográfico</value>

--- a/OneMore/Properties/Resources.fr-FR.resx
+++ b/OneMore/Properties/Resources.fr-FR.resx
@@ -868,11 +868,11 @@ Police de la dernière colonne</value>
     <comment>emoji</comment>
   </data>
   <data name="EmojiDialog.Text" xml:space="preserve">
-    <value>Titre Emojis</value>
+    <value>Insérer des émojis</value>
     <comment>dialog title</comment>
   </data>
   <data name="EmojiDialog_introLabel.Text" xml:space="preserve">
-    <value>Sélectionnez un ou plusieurs emojis à ajouter au titre de la page</value>
+    <value>Sélectionnez un ou plusieurs emojis à insérer</value>
     <comment>instructions</comment>
   </data>
   <data name="Error_BodyContext" xml:space="preserve">
@@ -2777,12 +2777,12 @@ Polaroïd</value>
     <comment>ribbon item screentip</comment>
   </data>
   <data name="ribEmojiButton_Label" xml:space="preserve">
-    <value>Ajouter un titre de page Emoji</value>
-    <comment>Ribbon OneMore menu item, Extras... EDIT</comment>
+    <value>Insérer un émoji</value>
+    <comment>ribbon edit</comment>
   </data>
   <data name="ribEmojiButton_Screentip" xml:space="preserve">
-    <value>Préparez le titre de la page avec des emojis</value>
-    <comment>ribbon page</comment>
+    <value>Insérez un ou plusieurs emojis</value>
+    <comment>ribbon edit</comment>
   </data>
   <data name="ribEnableSpellCheckButton_Label" xml:space="preserve">
     <value>Activer la vérification orthographique</value>

--- a/OneMore/Properties/Resources.he-IL.resx
+++ b/OneMore/Properties/Resources.he-IL.resx
@@ -882,11 +882,11 @@ Total Row Font
     <comment>emoji</comment>
   </data>
   <data name="EmojiDialog.Text" xml:space="preserve">
-    <value>תואר אמוג'ים</value>
+    <value>הכנס אמוג'י</value>
     <comment>dialog title</comment>
   </data>
   <data name="EmojiDialog_introLabel.Text" xml:space="preserve">
-    <value>בחר או יותר אמוג'ים כדי להוסיף לכותרת העמוד</value>
+    <value>בחר באימוג'י או יותר להוספה</value>
     <comment>instructions</comment>
   </data>
   <data name="Error_BodyContext" xml:space="preserve">
@@ -2802,12 +2802,12 @@ ISO-code then comma then language name</comment>
     <comment>ribbon item screentip</comment>
   </data>
   <data name="ribEmojiButton_Label" xml:space="preserve">
-    <value>הוסף אמוג'י כותרת עמוד</value>
-    <comment>ribbon page</comment>
+    <value>הכנס אימוג'י</value>
+    <comment>ribbon edit</comment>
   </data>
   <data name="ribEmojiButton_Screentip" xml:space="preserve">
-    <value>כותרת עמוד מקדימה עם אמוג'ים</value>
-    <comment>ribbon page</comment>
+    <value>הכנס אימוג'י אחד או יותר</value>
+    <comment>ribbon edit</comment>
   </data>
   <data name="ribEnableSpellCheckButton_Label" xml:space="preserve">
     <value>אפשר בדיקת איות</value>

--- a/OneMore/Properties/Resources.nl-NL.resx
+++ b/OneMore/Properties/Resources.nl-NL.resx
@@ -872,11 +872,11 @@ Lettertype laatste kolom</value>
     <comment>emoji</comment>
   </data>
   <data name="EmojiDialog.Text" xml:space="preserve">
-    <value>Titel Emoji's</value>
+    <value>Emoji's invoegen</value>
     <comment>dialog title</comment>
   </data>
   <data name="EmojiDialog_introLabel.Text" xml:space="preserve">
-    <value>Selecteer een of meer emoji's om toe te voegen aan de paginatitel</value>
+    <value>Selecteer een of meer emoji's om in te voegen</value>
     <comment>instructions</comment>
   </data>
   <data name="Error_BodyContext" xml:space="preserve">
@@ -2782,12 +2782,12 @@ Polaroid</value>
     <comment>ribbon item screentip</comment>
   </data>
   <data name="ribEmojiButton_Label" xml:space="preserve">
-    <value>Paginatitel-emoji toevoegen</value>
-    <comment>Ribbon OneMore menu item, Extras... EDIT</comment>
+    <value>Emoji invoegen</value>
+    <comment>ribbon edit</comment>
   </data>
   <data name="ribEmojiButton_Screentip" xml:space="preserve">
-    <value>Prepent paginatitel met emoji's</value>
-    <comment>ribbon page</comment>
+    <value>Voeg een of meer emoji's in</value>
+    <comment>ribbon edit</comment>
   </data>
   <data name="ribEnableSpellCheckButton_Label" xml:space="preserve">
     <value>Spellingcontrole inschakelen</value>

--- a/OneMore/Properties/Resources.pl-PL.resx
+++ b/OneMore/Properties/Resources.pl-PL.resx
@@ -880,11 +880,11 @@ Czcionka ostatniej kolumny</value>
     <comment>emoji</comment>
   </data>
   <data name="EmojiDialog.Text" xml:space="preserve">
-    <value>Tytułowe emotikony</value>
+    <value>Wstaw emotikony</value>
     <comment>dialog title</comment>
   </data>
   <data name="EmojiDialog_introLabel.Text" xml:space="preserve">
-    <value>Wybierz emotikony lub więcej, aby dodać je do tytułu strony</value>
+    <value>Wybierz co najmniej jeden emoji, który chcesz wstawić</value>
     <comment>instructions</comment>
   </data>
   <data name="Error_BodyContext" xml:space="preserve">
@@ -2794,12 +2794,12 @@ Polaroid</value>
     <comment>ribbon item screentip</comment>
   </data>
   <data name="ribEmojiButton_Label" xml:space="preserve">
-    <value>Dodaj emoji tytułu strony</value>
-    <comment>Ribbon OneMore menu item, Extras... EDIT</comment>
+    <value>Wstaw emoji</value>
+    <comment>ribbon edit</comment>
   </data>
   <data name="ribEmojiButton_Screentip" xml:space="preserve">
-    <value>Przygotuj tytuł strony za pomocą emotikonów</value>
-    <comment>ribbon page</comment>
+    <value>Wstaw jeden lub więcej emoji</value>
+    <comment>ribbon edit</comment>
   </data>
   <data name="ribEnableSpellCheckButton_Label" xml:space="preserve">
     <value>Włącz sprawdzanie pisowni</value>

--- a/OneMore/Properties/Resources.pt-BR.resx
+++ b/OneMore/Properties/Resources.pt-BR.resx
@@ -872,11 +872,11 @@ Fonte da última coluna</value>
     <comment>emoji</comment>
   </data>
   <data name="EmojiDialog.Text" xml:space="preserve">
-    <value>Título Emojis</value>
+    <value>Inserir emojis</value>
     <comment>dialog title</comment>
   </data>
   <data name="EmojiDialog_introLabel.Text" xml:space="preserve">
-    <value>Selecione um ou mais emojis para adicionar ao título da página</value>
+    <value>Selecione um ou mais emojis para inserir</value>
     <comment>instructions</comment>
   </data>
   <data name="Error_BodyContext" xml:space="preserve">
@@ -2782,12 +2782,12 @@ Polaroid.</value>
     <comment>ribbon item screentip</comment>
   </data>
   <data name="ribEmojiButton_Label" xml:space="preserve">
-    <value>Adicionar emoji de título de página</value>
-    <comment>Ribbon OneMore menu item, Extras... EDIT</comment>
+    <value>Inserir emoji</value>
+    <comment>ribbon edit</comment>
   </data>
   <data name="ribEmojiButton_Screentip" xml:space="preserve">
-    <value>Título da página anterior com emojis</value>
-    <comment>ribbon page</comment>
+    <value>Insira um ou mais emojis</value>
+    <comment>ribbon edit</comment>
   </data>
   <data name="ribEnableSpellCheckButton_Label" xml:space="preserve">
     <value>Ativar verificação ortográfica</value>

--- a/OneMore/Properties/Resources.resx
+++ b/OneMore/Properties/Resources.resx
@@ -886,11 +886,11 @@ Last Column Font</value>
     <comment>emoji</comment>
   </data>
   <data name="EmojiDialog.Text" xml:space="preserve">
-    <value>TItle Emojis</value>
+    <value>Insert Emojis</value>
     <comment>dialog title</comment>
   </data>
   <data name="EmojiDialog_introLabel.Text" xml:space="preserve">
-    <value>Select on or more emojis to add to page title</value>
+    <value>Select on or more emojis to insert</value>
     <comment>instructions</comment>
   </data>
   <data name="Error_BodyContext" xml:space="preserve">
@@ -2822,12 +2822,12 @@ Polaroid</value>
     <comment>ribbon references</comment>
   </data>
   <data name="ribEmojiButton_Label" xml:space="preserve">
-    <value>Add Page Title Emoji</value>
-    <comment>ribbon page</comment>
+    <value>Insert Emoji</value>
+    <comment>ribbon edit</comment>
   </data>
   <data name="ribEmojiButton_Screentip" xml:space="preserve">
-    <value>Prepent page title with emojis</value>
-    <comment>ribbon page</comment>
+    <value>Insert one or more emojis</value>
+    <comment>ribbon edit</comment>
   </data>
   <data name="ribEnableSpellCheckButton_Label" xml:space="preserve">
     <value>Enable Spell Check</value>

--- a/OneMore/Properties/Resources.zh-CN.resx
+++ b/OneMore/Properties/Resources.zh-CN.resx
@@ -879,11 +879,11 @@ OneNote 将自动关闭</value>
     <comment>emoji</comment>
   </data>
   <data name="EmojiDialog.Text" xml:space="preserve">
-    <value>标题表情符号</value>
+    <value>插入表情符号</value>
     <comment>dialog title</comment>
   </data>
   <data name="EmojiDialog_introLabel.Text" xml:space="preserve">
-    <value>选择一个或多个表情符号以添加到页面标题</value>
+    <value>选择一个或多个要插入的表情符号</value>
     <comment>instructions</comment>
   </data>
   <data name="Error_BodyContext" xml:space="preserve">
@@ -2813,12 +2813,12 @@ ISO-code then comma then language name</comment>
     <comment>ribbon item screentip</comment>
   </data>
   <data name="ribEmojiButton_Label" xml:space="preserve">
-    <value>添加页面标题表情符号</value>
-    <comment>Ribbon OneMore menu item, Extras... EDIT</comment>
+    <value>插入表情符号</value>
+    <comment>ribbon edit</comment>
   </data>
   <data name="ribEmojiButton_Screentip" xml:space="preserve">
-    <value>带有表情符号的前置页面标题</value>
-    <comment>ribbon page</comment>
+    <value>插入一个或多个表情符号</value>
+    <comment>ribbon edit</comment>
   </data>
   <data name="ribEnableSpellCheckButton_Label" xml:space="preserve">
     <value>启用拼写检查</value>

--- a/OneMore/Ribbon/Ribbon.xml
+++ b/OneMore/Ribbon/Ribbon.xml
@@ -324,6 +324,12 @@
                 getScreentip="GetRibbonScreentip"
                 onAction="IncreaseFontSizeCmd"/>
               <button
+                id="ribEmojiButton"
+                imageMso="ShapeSmileyFace"
+                getLabel="GetRibbonLabel"
+                getScreentip="GetRibbonScreentip"
+                onAction="EmojiCmd"/>
+              <button
                 id="ribDuplicateLineButton"
                 imageMso="PasteDuplicate"
                 getLabel="GetRibbonLabel"
@@ -518,12 +524,6 @@
                 getLabel="GetRibbonLabel"
                 getScreentip="GetRibbonScreentip"
                 onAction="ArrangeContainersCmd"/>
-              <button
-                id="ribEmojiButton"
-                imageMso="DataGraphicIconSet"
-                getLabel="GetRibbonLabel"
-                getScreentip="GetRibbonScreentip"
-                onAction="EmojiCmd"/>
               <button
                 id="ribCaptionAttachmentsButton"
                 imageMso="CaptionInsert"


### PR DESCRIPTION
The Add Title Emoji command only allows users to prepend the title with selected emojis. It would be preferrable to insert selected emojis at the current text insertion point, possibly replacing selected text.

Move the command from the Page menu to the Edit menu and rename to _Insert Emojis_