### PR TITLE
1903 allow dup fav in dialog

### DIFF
--- a/OneMore/Commands/Favorites/FavoritesDialog.cs
+++ b/OneMore/Commands/Favorites/FavoritesDialog.cs
@@ -432,7 +432,7 @@ namespace River.OneMoreAddIn.Commands.Favorites
 			Favorite favorite = null;
 			while (index < source.Count && favorite == null)
 			{
-				if (source[index].Location.EqualsICIC(info.Path))
+				if (source[index].ObjectID == info.PageId)
 				{
 					favorite = source[index];
 				}


### PR DESCRIPTION
#1903

* Allow duplicate page names in Favorites dialog, as long as the pageID is different.
* Auto-correct page names along with Check Favorites function