### PR TITLE
Update 'OneNote' to 'OneMore' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ OneMore is an add-in for OneNote with simple and powerful features that make One
 
 * Download the [latest release](https://github.com/stevencohn/OneMore/releases/latest)
 * Read the [installation instructions](https://onemoreaddin.com/get-started/How%20to%20Install%20OneMore.htm)
-* See the new [OneNote Wiki](https://onemoreaddin.com/) for a full user guide
+* See the new [OneMore Wiki](https://onemoreaddin.com/) for a full user guide
 
 # [![version](https://img.shields.io/github/v/release/stevencohn/OneMore?display_name=tag&color=7E5C81)](https://github.com/stevencohn/OneMore/releases/latest) [![downloads](https://img.shields.io/github/downloads/stevencohn/OneMore/total?color=blue)](https://github.com/stevencohn/OneMore/releases/latest) [![platform](https://img.shields.io/badge/platform-windows%20%7C%20onenote%20desktop-649BC1)](https://onemoreaddin.com/get-started/How%20to%20Install%20OneNote.htm) [![GitHub license](https://img.shields.io/badge/license-mpl--2.0-BF6A48)](https://github.com/stevencohn/OneMore/blob/main/LICENSE) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://onemoreaddin.com/developers/Setup.htm) ![](https://tokei.rs/b1/github/project-jedi/jcl)
 


### PR DESCRIPTION
## IS YOUR COMMIT SIGNED?
#### Note that this repo requires all commits to be properly signed, [see here](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more info
---

in browser, should be auto-signed

## Enhancement or Defect Addressed by This PR

Typo


## Description of Proposed Changes

Says "OneNote wiki" but links to the OneMore wiki