### PR TITLE
Fix Updater architecture detection and x86 product-code lookup (#1994, #1981)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,34 @@ to `Environment.Is64BitProcess`, `RuntimeInformation.OSArchitecture`,
 `WOW6432Node`, or PE-header inspection is part of this machinery and is not
 incidental. See `OneMoreSetupActions/CLAUDE.md` for the enforcement rules.
 
+### ARM64EC heuristic — apply everywhere architecture is detected
+
+Office on ARM64 Windows ships as **ARM64EC**: binaries whose COFF `Machine`
+field is `IMAGE_FILE_MACHINE_AMD64` even though they run natively on ARM64.
+A plain PE-header read therefore misreports ARM64EC OneNote/OneMore as x64.
+
+**The required pattern** (used in `CheckBitnessAction.cs` and `Updater.cs`):
+
+```csharp
+Machine.I386  => /* x86 */,
+Machine.Arm64 => /* ARM64 */,
+Machine.Amd64 when RuntimeInformation.OSArchitecture == Architecture.Arm64
+              => /* ARM64  ← ARM64EC heuristic */,
+_             => /* x64 */
+```
+
+Apply this whenever selecting an installer, matching a registry path, or
+otherwise branching on the architecture of a binary running on this machine.
+
+**Do NOT apply it in `SessionLogger.GetAssemblyArchitecture`** — that method
+intentionally returns the literal PE value for diagnostics and telemetry.
+ARM64EC reporting as `"x64"` there is useful population data.
+
+**Do NOT use `RuntimeInformation.ProcessArchitecture`** as a shortcut for
+OneNote's architecture. The add-in runs in **dllhost.exe** (COM surrogate),
+not `ONENOTE.EXE`, so `ProcessArchitecture` reflects dllhost's bitness.
+Read `ONENOTE.EXE`'s PE header directly when you need OneNote's architecture.
+
 ## Conventions and norms
 
 - **Issues / PRs:** use the `gh` CLI. Default repo is `stevencohn/OneMore`

--- a/OneMore/Commands/Tools/Updater/Updater.cs
+++ b/OneMore/Commands/Tools/Updater/Updater.cs
@@ -50,6 +50,8 @@ namespace River.OneMoreAddIn.Commands.Tools.Updater
 			// x64 and ARM64 installs register under the 64-bit view;
 			// x86 installs register under Wow6432Node — probe both.
 			var path = @"Software\Microsoft\Windows\CurrentVersion\Uninstall";
+			string foundCode = null;
+			string foundDate = null;
 
 			void ProbeView(RegistryView view)
 			{
@@ -71,12 +73,12 @@ namespace River.OneMoreAddIn.Commands.Tools.Updater
 						if (key.GetValue("UninstallString") is string cmd &&
 							!string.IsNullOrEmpty(cmd))
 						{
-							productCode = cmd.Substring(cmd.IndexOf('{'));
+							foundCode = cmd.Substring(cmd.IndexOf('{'));
 						}
 
 						if (key.GetValue("InstallDate") is string indate)
 						{
-							InstalledDate = indate;
+							foundDate = indate;
 						}
 
 						break;
@@ -86,11 +88,13 @@ namespace River.OneMoreAddIn.Commands.Tools.Updater
 
 			ProbeView(RegistryView.Registry64);
 
-			if (string.IsNullOrEmpty(productCode))
+			if (string.IsNullOrEmpty(foundCode))
 			{
 				ProbeView(RegistryView.Registry32);
 			}
 
+			productCode = foundCode;
+			InstalledDate = foundDate;
 			InstalledVersion = AssemblyInfo.Version;
 			InstalledUrl = $"{TagUrl}/{InstalledVersion}";
 		}

--- a/OneMore/Commands/Tools/Updater/Updater.cs
+++ b/OneMore/Commands/Tools/Updater/Updater.cs
@@ -15,6 +15,8 @@ namespace River.OneMoreAddIn.Commands.Tools.Updater
 	using System.Diagnostics;
 	using System.IO;
 	using System.Reflection;
+	using System.Reflection.PortableExecutable;
+	using System.Runtime.InteropServices;
 	using System.Text.RegularExpressions;
 	using System.Threading.Tasks;
 	using System.Web.Script.Serialization;
@@ -45,21 +47,20 @@ namespace River.OneMoreAddIn.Commands.Tools.Updater
 
 		public Updater()
 		{
-			// get current installed info...
-
-			//var path = Environment.Is64BitProcess
-			//	? @"Software\Microsoft\Windows\CurrentVersion\Uninstall"
-			//	: @"SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall";
-
-			// since we only deploy a 64-bit installer now...
+			// x64 and ARM64 installs register under the 64-bit view;
+			// x86 installs register under Wow6432Node — probe both.
 			var path = @"Software\Microsoft\Windows\CurrentVersion\Uninstall";
 
-			using var hive = RegistryKey
-				.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry64);
-
-			using var root = hive.OpenSubKey(path);
-			if (root is not null)
+			void ProbeView(RegistryView view)
 			{
+				using var hive = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, view);
+				using var root = hive.OpenSubKey(path);
+				if (root is null)
+				{
+					logger.WriteLine($"updater: Registry key not found HKLM::{path} ({view})");
+					return;
+				}
+
 				foreach (var subName in root.GetSubKeyNames())
 				{
 					using var key = root.OpenSubKey(subName);
@@ -78,14 +79,16 @@ namespace River.OneMoreAddIn.Commands.Tools.Updater
 							InstalledDate = indate;
 						}
 
-						// found the OneMore key so our job is done here
 						break;
 					}
 				}
 			}
-			else
+
+			ProbeView(RegistryView.Registry64);
+
+			if (string.IsNullOrEmpty(productCode))
 			{
-				logger.WriteLine($"updater: Registry key not found HKLM::{path}");
+				ProbeView(RegistryView.Registry32);
 			}
 
 			InstalledVersion = AssemblyInfo.Version;
@@ -210,12 +213,35 @@ namespace River.OneMoreAddIn.Commands.Tools.Updater
 			}
 
 			// The msi will have one of these keywords in its name: x86, x64, or ARM64.
-			// The bitness of the executing assembly can tell us the msi to request.
-			var localPath = new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath;
-			var key = SessionLogger.GetAssemblyArchitecture(localPath);
+			// Read the PE header of the executing assembly to determine which installer to
+			// download. Apply the ARM64EC heuristic: Office on ARM64 ships as ARM64EC whose
+			// COFF Machine field reports Amd64; treat it as ARM64 so we download the right
+			// installer rather than silently pulling the x64 build on an ARM64 machine.
+			var localPath = Assembly.GetExecutingAssembly().Location;
+			string key;
+			try
+			{
+				using var stream = new FileStream(localPath, FileMode.Open, FileAccess.Read);
+				using var reader = new PEReader(stream);
+				key = reader.PEHeaders.CoffHeader.Machine switch
+				{
+					Machine.I386  => "x86",
+					Machine.Arm64 => "ARM64",
+					// ARM64EC reports Machine.Amd64 but runs natively on ARM64 Windows
+					Machine.Amd64 when RuntimeInformation.OSArchitecture == Architecture.Arm64
+						=> "ARM64",
+					_ => "x64"
+				};
+			}
+			catch (Exception exc)
+			{
+				logger.WriteLine($"error reading assembly header, defaulting to x64: {exc.Message}");
+				key = "x64";
+			}
+
 			logger.WriteLine($"architecture is {key}");
 
-			var asset = release.assets.Find(a => a.browser_download_url.Contains(key));
+			var asset = release.assets.Find(a => a.browser_download_url.Contains($"Setup{key}.msi"));
 			if (asset is null)
 			{
 				logger.WriteLine($"did not find installer asset for {key}");

--- a/OneMore/Helpers/SessionLogger.cs
+++ b/OneMore/Helpers/SessionLogger.cs
@@ -101,6 +101,9 @@ namespace River.OneMoreAddIn.Helpers
 		}
 
 
+		// Returns the literal PE machine type ("x86", "x64", "ARM64") for diagnostics and
+		// telemetry. Do NOT use this for installer selection — ARM64EC binaries report "x64"
+		// here even though they run on ARM64. Use RuntimeInformation.ProcessArchitecture instead.
 		public static string GetAssemblyArchitecture(string path)
 		{
 			try

--- a/OneMoreSetupActions/CLAUDE.md
+++ b/OneMoreSetupActions/CLAUDE.md
@@ -77,6 +77,16 @@ registry paths or `WOW6432Node` presence. The matching rules:
 On mismatch, the action shows a `MessageBox` telling the user which installer
 flavour to download, and returns `FAILURE` (1603).
 
+## Architecture detection — PE header is the right tool
+
+When code needs to pick the correct installer for the running machine, always read
+the **PE header** of the relevant binary (`PEReader.PEHeaders.CoffHeader.Machine`)
+and apply the **ARM64EC heuristic**: `Machine.Amd64` on an ARM64 OS means ARM64EC,
+not plain x64. Do NOT use `RuntimeInformation.ProcessArchitecture` as a shortcut —
+the add-in runs in **dllhost.exe** (COM surrogate), not in `ONENOTE.EXE`, so
+`ProcessArchitecture` reflects dllhost's bitness, not OneNote's. For OneNote's
+architecture, read `ONENOTE.EXE`'s PE header directly.
+
 ## References worth knowing
 
 - `System.Reflection.Metadata` / `System.Collections.Immutable` — used by


### PR DESCRIPTION
## Summary

Fixes two bugs in `Updater.cs` that caused wrong-installer selection and prevented x86 users from auto-updating.

- **ARM64EC architecture misdetection** (#1981): `Update()` was using `SessionLogger.GetAssemblyArchitecture` to read the PE header of the running add-in DLL to determine which installer asset to download. ARM64EC binaries (the format Office on ARM64 uses) report `Machine.Amd64` in their COFF header, so the Updater would always select the x64 installer on ARM64 machines with the ARM64 OneMore build installed. Fixed by applying the same ARM64EC heuristic used in `CheckBitnessAction`: `Machine.Amd64` on an ARM64 OS is treated as ARM64. Note: `SessionLogger.GetAssemblyArchitecture` is intentionally left unchanged — its callers (session header, telemetry) want the literal PE machine type, and ARM64EC reporting as `"x64"` there is useful population data.

- **Asset URL matching tightened**: Changed `Contains(key)` to `Contains($"Setup{key}.msi")` to match the documented asset naming convention (`OneMore_<ver>_Setup{x86|x64|ARM64}.msi`) exactly, preventing any future partial-substring ambiguity.

- **x86 installs could never auto-update** (#1994 related): The constructor probed only `RegistryView.Registry64` for the installed product code. x86 OneMore registers under `Wow6432Node` (the 32-bit view), so `productCode` was always null for x86 users and `Update()` returned immediately with "missing product code". Fixed by falling back to `RegistryView.Registry32` when the 64-bit probe finds nothing.

- **`SessionLogger.GetAssemblyArchitecture`**: Added a warning comment clarifying the method returns the literal PE machine type (for diagnostics/telemetry) and must not be used for installer selection.

Relates to #1994
Relates to #1981

## Test plan

- [ ] x64 Windows + x64 OneNote + x64 OneMore installed → update downloads `Setupx64.msi`
- [ ] x86 Windows + x86 OneNote + x86 OneMore installed → constructor finds product code via Registry32 fallback; update downloads `Setupx86.msi`
- [ ] ARM64 Windows + ARM64EC OneNote + ARM64 OneMore installed → PE header heuristic detects ARM64EC and selects `SetupARM64.msi` (was incorrectly downloading `Setupx64.msi` before)
- [ ] Log check: `architecture is {x86|x64|ARM64}` matches the installed flavour
- [ ] Log check: `downloading MSI from …Setup{arch}.msi` — filename ends with correct token
- [ ] Pre-release → stable update path: constructor still finds product code when upgrading from a pre-release build

🤖 Generated with [Claude Code](https://claude.com/claude-code)