### PR TITLE
Fix To Title Case no-op when text is UPPERCASE (#1988)

### DIFF
--- a/OneMore/Commands/Edit/ToCaseCommand.cs
+++ b/OneMore/Commands/Edit/ToCaseCommand.cs
@@ -97,6 +97,9 @@ namespace River.OneMoreAddIn.Commands
 				return info.TextInfo.ToUpper(text);
 			}
 
+			// pre-lowercase so ToTitleCase doesn't preserve all-caps words as acronyms, #1988
+			text = info.TextInfo.ToLower(text);
+
 			if (info.TwoLetterISOLanguageName == "en")
 			{
 				return ToProperTitleCase(info, text);
@@ -123,8 +126,8 @@ namespace River.OneMoreAddIn.Commands
 		 */
 		private string ToProperTitleCase(CultureInfo info, string text)
 		{
-			// capitalize each word
-			text = info.TextInfo.ToTitleCase(text.ToLower(info));
+			// capitalize each word (caller has already lowercased)
+			text = info.TextInfo.ToTitleCase(text);
 
 			// lowercase the exceptions...
 


### PR DESCRIPTION
Relates to #1988

## Summary

- `TextInfo.ToTitleCase` preserves entirely-uppercase words as acronyms, so `ToTitleCase("MONDAY")` returned `"MONDAY"` unchanged — explaining the "works only from lowercase" symptom.
- The English path in `ToProperTitleCase` already pre-lowercased before `ToTitleCase`; the non-English fallback at the bottom of `Recase` did not.
- Hoisted the pre-lowercase step from `ToProperTitleCase` up into `Recase` so both title-case branches are covered regardless of `Thread.CurrentCulture`. The branch selection (`TwoLetterISOLanguageName == "en"`) is driven by the OneMore language setting and can diverge from the user's content language, so an English-content user isn't guaranteed to hit the English path — which is likely why the reporter saw it and the maintainer didn't.

## Test plan

- [ ] Insert Calendar, select the `MONDAY..SUNDAY` header row, run Edit → To Title Case. Expect `Monday Tuesday Wednesday Thursday Friday Saturday Sunday`.
- [ ] Select `the quick BROWN fox and the lazy DOG`, run Edit → To Title Case. Expect `The Quick Brown Fox and the Lazy Dog` (short-word regex pass still lowercases `and` / `the`).
- [ ] To UPPERCASE and To lowercase still work (unchanged code paths, cheap sanity check).
- [ ] `.\build.ps1 -fast -local` succeeds; CI green.