### PR TITLE
Honor user Code style on Apply Styles to Page and singular apply (#1543)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -20,7 +20,8 @@
       "Bash(curl -s -o C:\\\\Users\\\\steve\\\\AppData\\\\Local\\\\Temp\\\\issue1988.png -L \"https://github.com/user-attachments/assets/3b933688-0d66-46d7-9504-00e3ed96f829\")",
       "Bash(dir C:\\\\Users\\\\steve\\\\AppData\\\\Local\\\\Temp\\\\issue1988.png)",
       "PowerShell(Join-Path *)",
-      "PowerShell(Get-Item *)"
+      "PowerShell(Get-Item *)",
+      "Bash(Select-Object -First 20)"
     ]
   }
 }

--- a/OneMore/Commands/Styles/ApplyStyleCommand.cs
+++ b/OneMore/Commands/Styles/ApplyStyleCommand.cs
@@ -311,7 +311,24 @@ namespace River.OneMoreAddIn.Commands
 
 		private void SetQuickStyle(Page page, XElement element, Style style)
 		{
-			if (style.StyleType == StyleType.Heading &&
+			if (style.IsCode)
+			{
+				// bind the paragraph to OneNote's "code" quickstyle so OneNote
+				// (and Apply Styles to Page) recognize it as code regardless
+				// of what it was before — heading, normal, cite, quote, etc.
+
+				var quick = page.GetQuickStyle(StandardStyles.Code);
+				var attr = element.Attribute("quickStyleIndex");
+				if (attr is null)
+				{
+					element.Add(new XAttribute("quickStyleIndex", quick.Index));
+				}
+				else
+				{
+					attr.Value = quick.Index.ToString();
+				}
+			}
+			else if (style.StyleType == StyleType.Heading &&
 				// must be in heading range h1=0..h6=5
 				style.Index < 6)
 			{

--- a/OneMore/Commands/Styles/ApplyStylesCommand.cs
+++ b/OneMore/Commands/Styles/ApplyStylesCommand.cs
@@ -132,7 +132,8 @@ namespace River.OneMoreAddIn.Commands
 				// and ignore all additional "p" occurances defined, QuickStyleDef[@name='p']
 				// I don't remember why but pulled out that logic Feb 7 2022
 
-				if (FindStyle(styles, name) is Style style)
+				var style = FindStyle(styles, name);
+				if (style is not null)
 				{
 					//logger.WriteLine(
 					//	$"~ name:{quick.Attribute("name").Value} style:{style.Name}");
@@ -151,8 +152,15 @@ namespace River.OneMoreAddIn.Commands
 						// spaceBetween should only apply to normal paragraphs
 						name == "p" ? spacing : null);
 
-					quick.SetAttributeValue("fontColor", style.Color);
-					quick.SetAttributeValue("highlightColor", style.Highlight);
+					// code styles never repaint the page's code quickstyle, so the
+					// user's syntax-highlighting (or any custom fontColor on the
+					// QuickStyleDef) is preserved; other styles honor their own
+					// ApplyColors setting
+					if (style.ApplyColors && !style.IsCode)
+					{
+						quick.SetAttributeValue("fontColor", style.Color);
+						quick.SetAttributeValue("highlightColor", style.Highlight);
+					}
 
 					quick.SetAttributeValue("italic", style.IsItalic.ToString().ToLower());
 					quick.SetAttributeValue("bold", style.IsBold.ToString().ToLower());
@@ -164,7 +172,19 @@ namespace River.OneMoreAddIn.Commands
 				}
 
 				var index = quick.Attribute("index").Value;
-				ClearInlineStyles(index, name == "p");
+
+				// preserve inline colors for code paragraphs (syntax highlighting)
+				// and for any style that opted out of ApplyColors; otherwise keep
+				// the historic behavior: Gray-clear normal "p" paragraphs (to keep
+				// deliberate accents) and All-clear everything else
+				var clearing =
+					style is not null && (style.IsCode || !style.ApplyColors)
+						? Stylizer.Clearing.Gray
+						: name == "p"
+							? Stylizer.Clearing.Gray
+							: Stylizer.Clearing.All;
+
+				ClearInlineStyles(index, clearing);
 			}
 
 			return applied;
@@ -195,7 +215,12 @@ namespace River.OneMoreAddIn.Commands
 					break;
 
 				case "code":
-					style = styles.SingleOrDefault(s => s.Name.ToLower() == "code")
+					// prefer the explicit IsCode flag (set by the user in the Edit
+					// Styles dialog, or migrated by StyleRecord for legacy themes)
+					// and fall back to conventional names so themes that haven't
+					// been resaved yet still resolve
+					style = styles.FirstOrDefault(s => s.IsCode)
+						?? styles.SingleOrDefault(s => s.Name.ToLower() == "code")
 						?? styles.SingleOrDefault(s => s.Name.ToLower() == "source code");
 					break;
 
@@ -247,10 +272,10 @@ namespace River.OneMoreAddIn.Commands
 
 
 		// when applying styles, we want to preserve any special treatments to paragraphs
-		// because that would be tedious for the user to restore manually if their intention 
+		// because that would be tedious for the user to restore manually if their intention
 		// was to keep those colors, but we want to clear all color styling from every other
 		// element type like headings, et al.
-		private void ClearInlineStyles(string index, bool paragraph)
+		private void ClearInlineStyles(string index, Stylizer.Clearing clearing)
 		{
 			var elements = page.Root.Descendants()
 				.Where(e => e.Attribute("quickStyleIndex")?.Value == index)
@@ -272,8 +297,7 @@ namespace River.OneMoreAddIn.Commands
 			{
 				foreach (var element in elements)
 				{
-					stylizer.Clear(element,
-						paragraph ? Stylizer.Clearing.Gray : Stylizer.Clearing.All);
+					stylizer.Clear(element, clearing);
 				}
 			}
 		}

--- a/OneMore/Commands/Styles/StyleDialog.Designer.cs
+++ b/OneMore/Commands/Styles/StyleDialog.Designer.cs
@@ -69,6 +69,7 @@
 			this.styleTypeLabel = new System.Windows.Forms.Label();
 			this.styleTypeBox = new System.Windows.Forms.ComboBox();
 			this.applyColorsBox = new River.OneMoreAddIn.UI.MoreCheckBox();
+			this.isCodeBox = new River.OneMoreAddIn.UI.MoreCheckBox();
 			this.familyBox = new River.OneMoreAddIn.UI.FontComboBox();
 			this.mainTools = new River.OneMoreAddIn.UI.MoreMenuStrip();
 			this.loadButton = new River.OneMoreAddIn.UI.MoreMenuItem();
@@ -121,7 +122,7 @@
 			// beforeLabel
 			// 
 			this.beforeLabel.AutoSize = true;
-			this.beforeLabel.Location = new System.Drawing.Point(18, 289);
+			this.beforeLabel.Location = new System.Drawing.Point(18, 320);
 			this.beforeLabel.Name = "beforeLabel";
 			this.beforeLabel.Size = new System.Drawing.Size(111, 20);
 			this.beforeLabel.TabIndex = 6;
@@ -131,7 +132,7 @@
 			// afterLabel
 			// 
 			this.afterLabel.AutoSize = true;
-			this.afterLabel.Location = new System.Drawing.Point(18, 326);
+			this.afterLabel.Location = new System.Drawing.Point(18, 357);
 			this.afterLabel.Name = "afterLabel";
 			this.afterLabel.Size = new System.Drawing.Size(98, 20);
 			this.afterLabel.TabIndex = 7;
@@ -176,7 +177,7 @@
 			// spaceBeforeSpinner
 			// 
 			this.spaceBeforeSpinner.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.spaceBeforeSpinner.Location = new System.Drawing.Point(169, 283);
+			this.spaceBeforeSpinner.Location = new System.Drawing.Point(169, 314);
 			this.spaceBeforeSpinner.Name = "spaceBeforeSpinner";
 			this.spaceBeforeSpinner.Size = new System.Drawing.Size(108, 31);
 			this.spaceBeforeSpinner.TabIndex = 7;
@@ -186,7 +187,7 @@
 			// spaceAfterSpinner
 			// 
 			this.spaceAfterSpinner.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.spaceAfterSpinner.Location = new System.Drawing.Point(169, 319);
+			this.spaceAfterSpinner.Location = new System.Drawing.Point(169, 350);
 			this.spaceAfterSpinner.Name = "spaceAfterSpinner";
 			this.spaceAfterSpinner.Size = new System.Drawing.Size(108, 31);
 			this.spaceAfterSpinner.TabIndex = 8;
@@ -199,7 +200,7 @@
             | System.Windows.Forms.AnchorStyles.Right)));
 			this.previewBox.BackColor = System.Drawing.Color.White;
 			this.previewBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.previewBox.Location = new System.Drawing.Point(296, 283);
+			this.previewBox.Location = new System.Drawing.Point(296, 314);
 			this.previewBox.Name = "previewBox";
 			this.previewBox.Size = new System.Drawing.Size(347, 107);
 			this.previewBox.TabIndex = 18;
@@ -213,7 +214,7 @@
 			this.cancelButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
 			this.cancelButton.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
 			this.cancelButton.ImageOver = null;
-			this.cancelButton.Location = new System.Drawing.Point(527, 585);
+			this.cancelButton.Location = new System.Drawing.Point(527, 629);
 			this.cancelButton.Name = "cancelButton";
 			this.cancelButton.ShowBorder = true;
 			this.cancelButton.Size = new System.Drawing.Size(116, 38);
@@ -231,7 +232,7 @@
 			this.okButton.DialogResult = System.Windows.Forms.DialogResult.OK;
 			this.okButton.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
 			this.okButton.ImageOver = null;
-			this.okButton.Location = new System.Drawing.Point(405, 585);
+			this.okButton.Location = new System.Drawing.Point(405, 629);
 			this.okButton.Name = "okButton";
 			this.okButton.ShowBorder = true;
 			this.okButton.Size = new System.Drawing.Size(116, 38);
@@ -249,7 +250,7 @@
 			this.namesBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
 			this.namesBox.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
 			this.namesBox.FormattingEnabled = true;
-			this.namesBox.Location = new System.Drawing.Point(18, 589);
+			this.namesBox.Location = new System.Drawing.Point(18, 633);
 			this.namesBox.Name = "namesBox";
 			this.namesBox.Size = new System.Drawing.Size(121, 33);
 			this.namesBox.TabIndex = 10;
@@ -271,6 +272,7 @@
 			this.bodyPanel.Controls.Add(this.styleTypeLabel);
 			this.bodyPanel.Controls.Add(this.styleTypeBox);
 			this.bodyPanel.Controls.Add(this.applyColorsBox);
+			this.bodyPanel.Controls.Add(this.isCodeBox);
 			this.bodyPanel.Controls.Add(this.nameLabel);
 			this.bodyPanel.Controls.Add(this.familyBox);
 			this.bodyPanel.Controls.Add(this.okButton);
@@ -287,7 +289,7 @@
 			this.bodyPanel.Location = new System.Drawing.Point(8, 35);
 			this.bodyPanel.Name = "bodyPanel";
 			this.bodyPanel.Padding = new System.Windows.Forms.Padding(15, 20, 15, 9);
-			this.bodyPanel.Size = new System.Drawing.Size(661, 635);
+			this.bodyPanel.Size = new System.Drawing.Size(661, 679);
 			this.bodyPanel.TabIndex = 25;
 			// 
 			// styleTools
@@ -477,7 +479,7 @@
 			this.ignoredBox.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(231)))), ((int)(((byte)(231)))), ((int)(((byte)(231)))));
 			this.ignoredBox.Cursor = System.Windows.Forms.Cursors.Hand;
 			this.ignoredBox.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-			this.ignoredBox.Location = new System.Drawing.Point(169, 244);
+			this.ignoredBox.Location = new System.Drawing.Point(169, 275);
 			this.ignoredBox.Name = "ignoredBox";
 			this.ignoredBox.Size = new System.Drawing.Size(176, 25);
 			this.ignoredBox.StylizeImage = false;
@@ -497,10 +499,10 @@
 			this.optionsGroup.Controls.Add(this.pageColorLink);
 			this.optionsGroup.Controls.Add(this.darkBox);
 			this.optionsGroup.Controls.Add(this.pageColorBox);
-			this.optionsGroup.Location = new System.Drawing.Point(22, 420);
+			this.optionsGroup.Location = new System.Drawing.Point(22, 458);
 			this.optionsGroup.Name = "optionsGroup";
 			this.optionsGroup.ShowOnlyTopEdge = true;
-			this.optionsGroup.Size = new System.Drawing.Size(620, 150);
+			this.optionsGroup.Size = new System.Drawing.Size(620, 156);
 			this.optionsGroup.TabIndex = 30;
 			this.optionsGroup.TabStop = false;
 			this.optionsGroup.Text = "Options";
@@ -528,6 +530,7 @@
 			this.pageColorLink.LinkColor = System.Drawing.Color.MediumOrchid;
 			this.pageColorLink.Location = new System.Drawing.Point(46, 90);
 			this.pageColorLink.Name = "pageColorLink";
+			this.pageColorLink.Selected = false;
 			this.pageColorLink.Size = new System.Drawing.Size(247, 20);
 			this.pageColorLink.StrictColors = false;
 			this.pageColorLink.TabIndex = 2;
@@ -573,7 +576,7 @@
 			// spacingLabel
 			// 
 			this.spacingLabel.AutoSize = true;
-			this.spacingLabel.Location = new System.Drawing.Point(18, 362);
+			this.spacingLabel.Location = new System.Drawing.Point(18, 393);
 			this.spacingLabel.Name = "spacingLabel";
 			this.spacingLabel.Size = new System.Drawing.Size(71, 20);
 			this.spacingLabel.TabIndex = 29;
@@ -583,7 +586,7 @@
 			// spacingSpinner
 			// 
 			this.spacingSpinner.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.spacingSpinner.Location = new System.Drawing.Point(169, 356);
+			this.spacingSpinner.Location = new System.Drawing.Point(169, 387);
 			this.spacingSpinner.Name = "spacingSpinner";
 			this.spacingSpinner.Size = new System.Drawing.Size(108, 31);
 			this.spacingSpinner.TabIndex = 9;
@@ -634,6 +637,23 @@
 			this.applyColorsBox.ThemedFore = null;
 			this.applyColorsBox.UseVisualStyleBackColor = true;
 			this.applyColorsBox.CheckedChanged += new System.EventHandler(this.ChangeApplyColorsOption);
+			// 
+			// isCodeBox
+			// 
+			this.isCodeBox.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(231)))), ((int)(((byte)(231)))), ((int)(((byte)(231)))));
+			this.isCodeBox.Cursor = System.Windows.Forms.Cursors.Hand;
+			this.isCodeBox.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
+			this.isCodeBox.Location = new System.Drawing.Point(169, 244);
+			this.isCodeBox.Name = "isCodeBox";
+			this.isCodeBox.Size = new System.Drawing.Size(188, 25);
+			this.isCodeBox.StylizeImage = false;
+			this.isCodeBox.TabIndex = 7;
+			this.isCodeBox.Text = "Source code paragraph";
+			this.isCodeBox.ThemedBack = null;
+			this.isCodeBox.ThemedFore = null;
+			this.tooltip.SetToolTip(this.isCodeBox, "Mark this as the code style used by Apply Styles to Page");
+			this.isCodeBox.UseVisualStyleBackColor = true;
+			this.isCodeBox.CheckedChanged += new System.EventHandler(this.ChangeIsCodeOption);
 			// 
 			// familyBox
 			// 
@@ -741,7 +761,7 @@
 			this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
 			this.CancelButton = this.cancelButton;
-			this.ClientSize = new System.Drawing.Size(676, 678);
+			this.ClientSize = new System.Drawing.Size(676, 722);
 			this.Controls.Add(this.mainTools);
 			this.Controls.Add(this.bodyPanel);
 			this.ForeColor = System.Drawing.SystemColors.ControlText;
@@ -798,6 +818,7 @@
 		private UI.MoreMenuItem deleteButton;
 		private System.Windows.Forms.Panel bodyPanel;
 		private UI.MoreCheckBox applyColorsBox;
+		private UI.MoreCheckBox isCodeBox;
 		private System.Windows.Forms.Label styleTypeLabel;
 		private System.Windows.Forms.ComboBox styleTypeBox;
 		private UI.MoreMenuItem loadButton;

--- a/OneMore/Commands/Styles/StyleDialog.cs
+++ b/OneMore/Commands/Styles/StyleDialog.cs
@@ -144,6 +144,7 @@ namespace River.OneMoreAddIn.Commands
 					"fontLabel",
 					"styleTypeLabel",
 					"applyColorsBox",
+					"isCodeBox",
 					// options
 					"optionsGroup=word_Options",
 					"darkBox",
@@ -313,6 +314,7 @@ namespace River.OneMoreAddIn.Commands
 			subButton.Checked = selection.IsSubscript;
 
 			applyColorsBox.Checked = selection.ApplyColors;
+			isCodeBox.Checked = selection.IsCode;
 			ignoredBox.Checked = selection.Ignored;
 
 			if (double.TryParse(selection.SpaceAfter, NumberStyles.Any, CultureInfo.InvariantCulture, out var sa))
@@ -515,13 +517,21 @@ namespace River.OneMoreAddIn.Commands
 						spaceAfterSpinner.Enabled = false;
 						spaceBeforeSpinner.Enabled = false;
 						spacingSpinner.Enabled = false;
+						isCodeBox.Enabled = isCodeBox.Checked = false;
 						break;
 
 					case StyleType.Paragraph:
+						spaceAfterSpinner.Enabled = true;
+						spaceBeforeSpinner.Enabled = true;
+						spacingSpinner.Enabled = true;
+						isCodeBox.Enabled = true;
+						break;
+
 					case StyleType.Heading:
 						spaceAfterSpinner.Enabled = true;
 						spaceBeforeSpinner.Enabled = true;
 						spacingSpinner.Enabled = true;
+						isCodeBox.Enabled = isCodeBox.Checked = false;
 						break;
 				}
 			}
@@ -672,6 +682,12 @@ namespace River.OneMoreAddIn.Commands
 				= applyColorsBox.Checked;
 
 			previewBox.Invalidate();
+		}
+
+
+		private void ChangeIsCodeOption(object sender, EventArgs e)
+		{
+			selection.IsCode = isCodeBox.Checked;
 		}
 
 

--- a/OneMore/Properties/Resources.Designer.cs
+++ b/OneMore/Properties/Resources.Designer.cs
@@ -12304,6 +12304,15 @@ namespace River.OneMoreAddIn.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Source code paragraph.
+        /// </summary>
+        internal static string StyleDialog_isCodeBox_Text {
+            get {
+                return ResourceManager.GetString("StyleDialog_isCodeBox.Text", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Italic.
         /// </summary>
         internal static string StyleDialog_italicButton_Text {

--- a/OneMore/Properties/Resources.ar-SA.resx
+++ b/OneMore/Properties/Resources.ar-SA.resx
@@ -5002,6 +5002,10 @@ ISO-code then comma then language name</comment>
     <value>تعطيل التدقيق الإملائي</value>
     <comment>checkbox</comment>
   </data>
+  <data name="StyleDialog_isCodeBox.Text" xml:space="preserve">
+    <value>فقرة كود المصدر</value>
+    <comment>checkbox</comment>
+  </data>
   <data name="StyleDialog_italicButton.Text" xml:space="preserve">
     <value>مائل</value>
     <comment>button</comment>

--- a/OneMore/Properties/Resources.de-DE.resx
+++ b/OneMore/Properties/Resources.de-DE.resx
@@ -4985,6 +4985,10 @@ Notizbücher</value>
     <value>Rechtschreibprüfung deaktivieren</value>
     <comment>checkbox</comment>
   </data>
+  <data name="StyleDialog_isCodeBox.Text" xml:space="preserve">
+    <value>Absatz zum Quellcode</value>
+    <comment>checkbox</comment>
+  </data>
   <data name="StyleDialog_italicButton.Text" xml:space="preserve">
     <value>Kursiv</value>
     <comment>button</comment>

--- a/OneMore/Properties/Resources.es-ES.resx
+++ b/OneMore/Properties/Resources.es-ES.resx
@@ -4990,6 +4990,10 @@ Cuadernos</value>
     <value>Desactivar el corrector ortográfico</value>
     <comment>checkbox</comment>
   </data>
+  <data name="StyleDialog_isCodeBox.Text" xml:space="preserve">
+    <value>Párrafo del código fuente</value>
+    <comment>checkbox</comment>
+  </data>
   <data name="StyleDialog_italicButton.Text" xml:space="preserve">
     <value>Itálico</value>
     <comment>button</comment>

--- a/OneMore/Properties/Resources.fr-FR.resx
+++ b/OneMore/Properties/Resources.fr-FR.resx
@@ -5000,6 +5000,10 @@ Des notebooks</value>
     <value>Désactiver la vérification orthographique</value>
     <comment>checkbox</comment>
   </data>
+  <data name="StyleDialog_isCodeBox.Text" xml:space="preserve">
+    <value>Paragraphe du code source</value>
+    <comment>checkbox</comment>
+  </data>
   <data name="StyleDialog_italicButton.Text" xml:space="preserve">
     <value>Italique</value>
     <comment>button</comment>

--- a/OneMore/Properties/Resources.he-IL.resx
+++ b/OneMore/Properties/Resources.he-IL.resx
@@ -4989,6 +4989,10 @@ ISO-code then comma then language name</comment>
     <value>השבת את בדיקת האיות</value>
     <comment>checkbox</comment>
   </data>
+  <data name="StyleDialog_isCodeBox.Text" xml:space="preserve">
+    <value>פסקת קוד המקור</value>
+    <comment>checkbox</comment>
+  </data>
   <data name="StyleDialog_italicButton.Text" xml:space="preserve">
     <value>נטוי</value>
     <comment>button</comment>

--- a/OneMore/Properties/Resources.it-IT.resx
+++ b/OneMore/Properties/Resources.it-IT.resx
@@ -4992,6 +4992,10 @@ Taccuini</value>
     <value>Disabilita il controllo ortografico</value>
     <comment>checkbox</comment>
   </data>
+  <data name="StyleDialog_isCodeBox.Text" xml:space="preserve">
+    <value>Paragrafo del codice sorgente</value>
+    <comment>checkbox</comment>
+  </data>
   <data name="StyleDialog_italicButton.Text" xml:space="preserve">
     <value>Corsivo</value>
     <comment>button</comment>

--- a/OneMore/Properties/Resources.ja-JP.resx
+++ b/OneMore/Properties/Resources.ja-JP.resx
@@ -4994,6 +4994,10 @@ ISO-code then comma then language name</comment>
     <value>スペルチェックを無効にする</value>
     <comment>checkbox</comment>
   </data>
+  <data name="StyleDialog_isCodeBox.Text" xml:space="preserve">
+    <value>ソースコードの段落</value>
+    <comment>checkbox</comment>
+  </data>
   <data name="StyleDialog_italicButton.Text" xml:space="preserve">
     <value>イタリック</value>
     <comment>button</comment>

--- a/OneMore/Properties/Resources.nl-NL.resx
+++ b/OneMore/Properties/Resources.nl-NL.resx
@@ -4990,6 +4990,10 @@ Notitieboekjes</value>
     <value>Schakel de spellingcontrole uit</value>
     <comment>checkbox</comment>
   </data>
+  <data name="StyleDialog_isCodeBox.Text" xml:space="preserve">
+    <value>Broncodeparagraaf</value>
+    <comment>checkbox</comment>
+  </data>
   <data name="StyleDialog_italicButton.Text" xml:space="preserve">
     <value>Cursief</value>
     <comment>button</comment>

--- a/OneMore/Properties/Resources.pl-PL.resx
+++ b/OneMore/Properties/Resources.pl-PL.resx
@@ -4991,6 +4991,10 @@ Notatniki</value>
     <value>Wyłącz sprawdzanie pisowni</value>
     <comment>checkbox</comment>
   </data>
+  <data name="StyleDialog_isCodeBox.Text" xml:space="preserve">
+    <value>Akapit kodu źródłowego</value>
+    <comment>checkbox</comment>
+  </data>
   <data name="StyleDialog_italicButton.Text" xml:space="preserve">
     <value>italski</value>
     <comment>button</comment>

--- a/OneMore/Properties/Resources.pt-BR.resx
+++ b/OneMore/Properties/Resources.pt-BR.resx
@@ -4990,6 +4990,10 @@ cadernos</value>
     <value>Desativar verificação ortográfica</value>
     <comment>checkbox</comment>
   </data>
+  <data name="StyleDialog_isCodeBox.Text" xml:space="preserve">
+    <value>Parágrafo do código-fonte</value>
+    <comment>checkbox</comment>
+  </data>
   <data name="StyleDialog_italicButton.Text" xml:space="preserve">
     <value>itálico</value>
     <comment>button</comment>

--- a/OneMore/Properties/Resources.resx
+++ b/OneMore/Properties/Resources.resx
@@ -4983,6 +4983,10 @@ Notebooks</value>
     <value>Apply colors</value>
     <comment>checkbox</comment>
   </data>
+  <data name="StyleDialog_isCodeBox.Text" xml:space="preserve">
+    <value>Source code paragraph</value>
+    <comment>checkbox</comment>
+  </data>
   <data name="StyleDialog_backColorButton.ToolTipText" xml:space="preserve">
     <value>Highlight Color</value>
     <comment>button tip</comment>

--- a/OneMore/Properties/Resources.resx
+++ b/OneMore/Properties/Resources.resx
@@ -4983,10 +4983,6 @@ Notebooks</value>
     <value>Apply colors</value>
     <comment>checkbox</comment>
   </data>
-  <data name="StyleDialog_isCodeBox.Text" xml:space="preserve">
-    <value>Source code paragraph</value>
-    <comment>checkbox</comment>
-  </data>
   <data name="StyleDialog_backColorButton.ToolTipText" xml:space="preserve">
     <value>Highlight Color</value>
     <comment>button tip</comment>
@@ -5026,6 +5022,10 @@ Notebooks</value>
   </data>
   <data name="StyleDialog_ignoredBox.Text" xml:space="preserve">
     <value>Disable spell check</value>
+    <comment>checkbox</comment>
+  </data>
+  <data name="StyleDialog_isCodeBox.Text" xml:space="preserve">
+    <value>Source code paragraph</value>
     <comment>checkbox</comment>
   </data>
   <data name="StyleDialog_italicButton.Text" xml:space="preserve">

--- a/OneMore/Properties/Resources.zh-CN.resx
+++ b/OneMore/Properties/Resources.zh-CN.resx
@@ -4995,6 +4995,10 @@ ISO-code then comma then language name</comment>
     <value>禁用拼写检查</value>
     <comment>checkbox</comment>
   </data>
+  <data name="StyleDialog_isCodeBox.Text" xml:space="preserve">
+    <value>源码段</value>
+    <comment>checkbox</comment>
+  </data>
   <data name="StyleDialog_italicButton.Text" xml:space="preserve">
     <value>斜体</value>
     <comment>button</comment>

--- a/OneMore/Styles/DefaultStyles.xml
+++ b/OneMore/Styles/DefaultStyles.xml
@@ -9,7 +9,7 @@
   <Style index="6" name="Page Title" font="Calibri Light" fontColor="#464646" fontSize="20.0" spaceBefore="0.0" spaceAfter="14.0" applyColors="true" styleType="Paragraph" />
   <Style index="7" name="Citation" font="Calibri" fontColor="#595959" fontSize="9.0" spaceBefore="0.0" spaceAfter="0.0" applyColors="true" styleType="Paragraph" />
   <Style index="8" name="Quote" font="Calibri" fontColor="#595959" fontSize="11.0" italic="true" spaceBefore="0.0" spaceAfter="0.0" applyColors="true" styleType="Paragraph" />
-  <Style index="9" name="Code" font="Lucida Console" fontColor="Black" fontSize="9.0" spaceBefore="0.0" spaceAfter="0.0" applyColors="false" styleType="Paragraph" ignored="true" />
+  <Style index="9" name="Code" font="Lucida Console" fontColor="Black" fontSize="9.0" spaceBefore="0.0" spaceAfter="0.0" applyColors="false" styleType="Paragraph" ignored="true" isCode="true" />
   <Style index="10" name="Normal" font="Calibri" fontColor="Black" fontSize="11.0" spaceBefore="0.0" spaceAfter="0.0" applyColors="true" styleType="Paragraph" />
   <Style index="11" name="Strong" font="Calibri" fontColor="Black" fontSize="11.0" bold="true" spaceBefore="0.0" spaceAfter="0.0" applyColors="true" styleType="Character" />
   <Style index="12" name="Emphasis" font="Calibri" fontColor="#4F81BD" fontSize="11.0" bold="true" italic="true" spaceBefore="0.0" spaceAfter="0.0" applyColors="true" styleType="Character" />

--- a/OneMore/Styles/StyleBase.cs
+++ b/OneMore/Styles/StyleBase.cs
@@ -111,6 +111,7 @@ namespace River.OneMoreAddIn.Styles
 			Ignored = other.Ignored;
 
 			ApplyColors = other.ApplyColors;
+			IsCode = other.IsCode;
 		}
 
 
@@ -265,6 +266,18 @@ namespace River.OneMoreAddIn.Styles
 		/// Stored by StyleRecord and used by Style but ignored by QuickStyleDef
 		/// </remarks>
 		public bool ApplyColors { get; set; }
+
+
+		/// <summary>
+		/// Gets or sets a Boolean indicating that this style represents the user's
+		/// preferred code style. When true, "Apply Styles to Page" treats
+		/// OneNote code-quickstyle paragraphs as targets for this style and
+		/// preserves any inline colors (e.g. syntax highlighting) on them.
+		/// </summary>
+		/// <remarks>
+		/// Stored by StyleRecord and used by Style but ignored by QuickStyleDef
+		/// </remarks>
+		public bool IsCode { get; set; }
 
 
 		/// <summary>

--- a/OneMore/Styles/StyleRecord.cs
+++ b/OneMore/Styles/StyleRecord.cs
@@ -60,6 +60,18 @@ namespace River.OneMoreAddIn.Styles
 			if (element.GetAttributeValue("applyColors", out bool applyColors, false))
 				ApplyColors = applyColors;
 
+			if (element.GetAttributeValue("isCode", out bool isCode, false))
+			{
+				IsCode = isCode;
+			}
+			else if (!string.IsNullOrEmpty(Name))
+			{
+				// reader-makes-right migration for themes that pre-date the
+				// isCode attribute: infer from the conventional style name
+				var lower = Name.ToLowerInvariant();
+				IsCode = lower == "code" || lower == "source code";
+			}
+
 			if (element.GetAttributeValue("bold", out bool bold, false))
 				IsBold = bold;
 
@@ -108,6 +120,11 @@ namespace River.OneMoreAddIn.Styles
 
 			writer.WriteAttributeString("applyColors", ApplyColors.ToString().ToLower());
 			writer.WriteAttributeString("styleType", StyleType.ToString());
+
+			if (IsCode)
+			{
+				writer.WriteAttributeString("isCode", "true");
+			}
 		}
 	}
 }

--- a/Themes/Confluence6.xml
+++ b/Themes/Confluence6.xml
@@ -9,7 +9,7 @@
   <Style index="6" name="Page Title" font="Calibri Light" fontSize="20" fontColor="#ff464646" spaceBefore="0" spaceAfter="14" styleType="Paragraph" />
   <Style index="7" name="Citation" font="Calibri" fontSize="9" fontColor="#ff595959" spaceBefore="0" spaceAfter="0" styleType="Paragraph" />
   <Style index="8" name="Quote" font="Arial" fontSize="10" italic="true" fontColor="#ff7F7F7F" spaceBefore="0" spaceAfter="0" styleType="Paragraph" />
-  <Style index="9" name="Code" font="Calibri" fontSize="10" fontColor="#ff333333" spaceBefore="0" spaceAfter="0" styleType="Paragraph" />
+  <Style index="9" name="Code" font="Calibri" fontSize="10" fontColor="#ff333333" spaceBefore="0" spaceAfter="0" styleType="Paragraph" isCode="true" />
   <Style index="10" name="Normal" font="Arial" fontSize="10" fontColor="#ff333333" spaceBefore="6" spaceAfter="0" styleType="Paragraph" />
   <Style index="11" name="Strong" font="Arial" fontSize="10" bold="true" fontColor="#ff333333" spaceBefore="0" spaceAfter="0" styleType="Character" />
   <Style index="12" name="Emphasis" font="Arial" fontSize="10" bold="true" italic="true" fontColor="#ff5B9BD5" spaceBefore="0" spaceAfter="0" styleType="Character" />

--- a/Themes/Confluence7.xml
+++ b/Themes/Confluence7.xml
@@ -9,7 +9,7 @@
   <Style index="6" name="Page Title" font="Calibri Light" fontColor="#151515" fontSize="20.0" spaceBefore="0.0" spaceAfter="14.0" applyColors="true" styleType="Paragraph" />
   <Style index="7" name="Citation" font="Segoe UI" fontColor="#5E6C84" fontSize="9.0" spaceBefore="0.0" spaceAfter="0.0" applyColors="true" styleType="Paragraph" />
   <Style index="8" name="Quote" font="Segoe UI" fontColor="#5E6C84" fontSize="11.0" spaceBefore="0.0" spaceAfter="0.0" applyColors="true" styleType="Paragraph" />
-  <Style index="9" name="Code" font="Consolas" fontColor="#FFFFFF" fontSize="10.0" spaceBefore="0.0" spaceAfter="0.0" applyColors="false" styleType="Paragraph" />
+  <Style index="9" name="Code" font="Consolas" fontColor="#FFFFFF" fontSize="10.0" spaceBefore="0.0" spaceAfter="0.0" applyColors="false" styleType="Paragraph" isCode="true" />
   <Style index="10" name="Normal" font="Segoe UI" fontColor="#000000" fontSize="11.0" spaceBefore="0.0" spaceAfter="0.0" applyColors="true" styleType="Paragraph" />
   <Style index="11" name="Strong" font="Segoe UI" fontColor="#000000" fontSize="11.0" bold="true" spaceBefore="0.0" spaceAfter="0.0" applyColors="true" styleType="Character" />
   <Style index="12" name="Emphasis" font="Segoe UI" fontColor="#0080FF" fontSize="11.0" bold="true" italic="true" spaceBefore="0.0" spaceAfter="0.0" applyColors="true" styleType="Character" />

--- a/Themes/DarkBlue.xml
+++ b/Themes/DarkBlue.xml
@@ -9,7 +9,7 @@
   <Style index="6" name="Page Title" font="Calibri Light" fontColor="#FFFFFF" fontSize="20.0" spaceBefore="0.0" spaceAfter="14.0" applyColors="true" styleType="Paragraph" />
   <Style index="7" name="Citation" font="Segoe UI" fontColor="#B2B089" fontSize="9.0" spaceBefore="0.0" spaceAfter="0.0" applyColors="true" styleType="Paragraph" />
   <Style index="8" name="Quote" font="Segoe UI" fontColor="#B2B089" fontSize="11.0" spaceBefore="0.0" spaceAfter="0.0" applyColors="true" styleType="Paragraph" />
-  <Style index="9" name="Code" font="Consolas" fontColor="#FFFFFF" fontSize="10.0" spaceBefore="0.0" spaceAfter="0.0" applyColors="false" styleType="Paragraph" />
+  <Style index="9" name="Code" font="Consolas" fontColor="#FFFFFF" fontSize="10.0" spaceBefore="0.0" spaceAfter="0.0" applyColors="false" styleType="Paragraph" isCode="true" />
   <Style index="10" name="Normal" font="Segoe UI" fontColor="#EEEEEE" fontSize="11.0" spaceBefore="0.0" spaceAfter="0.0" applyColors="true" styleType="Paragraph" />
   <Style index="11" name="Strong" font="Segoe UI" fontColor="#FFFFFF" fontSize="11.0" bold="true" spaceBefore="0.0" spaceAfter="0.0" applyColors="true" styleType="Character" />
   <Style index="12" name="Emphasis" font="Segoe UI" fontColor="#0080FF" fontSize="11.0" bold="true" italic="true" spaceBefore="0.0" spaceAfter="0.0" applyColors="true" styleType="Character" />

--- a/Themes/DarkGreen.xml
+++ b/Themes/DarkGreen.xml
@@ -9,7 +9,7 @@
   <Style index="6" name="Page Title" font="Calibri Light" fontColor="#FFFFFF" fontSize="20.0" spaceBefore="0.0" spaceAfter="14.0" applyColors="true" styleType="Paragraph" />
   <Style index="7" name="Citation" font="Segoe UI" fontColor="#B2B089" fontSize="9.0" spaceBefore="0.0" spaceAfter="0.0" applyColors="true" styleType="Paragraph" />
   <Style index="8" name="Quote" font="Segoe UI" fontColor="#B2B089" fontSize="11.0" spaceBefore="0.0" spaceAfter="0.0" applyColors="true" styleType="Paragraph" />
-  <Style index="9" name="Code" font="Consolas" fontColor="#FFFFFF" fontSize="10.0" spaceBefore="0.0" spaceAfter="0.0" applyColors="false" styleType="Paragraph" />
+  <Style index="9" name="Code" font="Consolas" fontColor="#FFFFFF" fontSize="10.0" spaceBefore="0.0" spaceAfter="0.0" applyColors="false" styleType="Paragraph" isCode="true" />
   <Style index="10" name="Normal" font="Segoe UI" fontColor="#EEEEEE" fontSize="11.0" spaceBefore="0.0" spaceAfter="0.0" applyColors="true" styleType="Paragraph" />
   <Style index="11" name="Strong" font="Segoe UI" fontColor="#FFFFFF" fontSize="11.0" bold="true" spaceBefore="0.0" spaceAfter="0.0" applyColors="true" styleType="Character" />
   <Style index="12" name="Emphasis" font="Segoe UI" fontColor="#33AA00" fontSize="11.0" bold="true" italic="true" spaceBefore="0.0" spaceAfter="0.0" applyColors="true" styleType="Character" />

--- a/Themes/DarkOrange.xml
+++ b/Themes/DarkOrange.xml
@@ -9,7 +9,7 @@
   <Style index="6" name="Page Title" font="Calibri Light" fontColor="#FFFFFF" fontSize="20.0" spaceBefore="0.0" spaceAfter="14.0" spacing="0.0" applyColors="true" styleType="Paragraph" />
   <Style index="7" name="Citation" font="Calibri" fontColor="#F3F3F3" fontSize="9.0" spaceBefore="0.0" spaceAfter="0.0" spacing="0.0" applyColors="true" styleType="Paragraph" />
   <Style index="8" name="Quote" font="Calibri" fontColor="#A5A5A5" fontSize="11.0" italic="true" spaceBefore="0.0" spaceAfter="0.0" spacing="0.0" applyColors="true" styleType="Paragraph" />
-  <Style index="9" name="Code" font="Lucida Console" fontColor="#F3F3F3" fontSize="9.0" spaceBefore="0.0" spaceAfter="0.0" spacing="0.0" applyColors="true" styleType="Paragraph" />
+  <Style index="9" name="Code" font="Lucida Console" fontColor="#F3F3F3" fontSize="9.0" spaceBefore="0.0" spaceAfter="0.0" spacing="0.0" applyColors="true" styleType="Paragraph" isCode="true" />
   <Style index="10" name="Normal" font="Calibri" fontColor="#F3F3F3" fontSize="11.0" spaceBefore="0.0" spaceAfter="0.0" spacing="0.0" applyColors="true" styleType="Paragraph" />
   <Style index="11" name="Strong" font="Calibri" fontColor="#F1F1F1" fontSize="11.0" bold="true" spaceBefore="0.0" spaceAfter="0.0" spacing="0.0" applyColors="true" styleType="Character" />
   <Style index="12" name="Emphasis" font="Calibri" fontColor="#779DCC" fontSize="11.0" bold="true" italic="true" spaceBefore="0.0" spaceAfter="0.0" spacing="0.0" applyColors="true" styleType="Character" />

--- a/Themes/Orange.xml
+++ b/Themes/Orange.xml
@@ -9,7 +9,7 @@
   <Style index="6" name="Page Title" font="Calibri Light" fontColor="#464646" fontSize="20.0" spaceBefore="0.0" spaceAfter="14.0" applyColors="true" styleType="Paragraph" />
   <Style index="7" name="Citation" font="Calibri" fontColor="#595959" fontSize="9.0" spaceBefore="0.0" spaceAfter="0.0" applyColors="true" styleType="Paragraph" />
   <Style index="8" name="Quote" font="Calibri" fontColor="#595959" fontSize="11.0" italic="true" spaceBefore="0.0" spaceAfter="0.0" applyColors="true" styleType="Paragraph" />
-  <Style index="9" name="Code" font="Lucida Console" fontColor="Black" fontSize="9.0" spaceBefore="0.0" spaceAfter="0.0" applyColors="false" styleType="Paragraph" />
+  <Style index="9" name="Code" font="Lucida Console" fontColor="Black" fontSize="9.0" spaceBefore="0.0" spaceAfter="0.0" applyColors="false" styleType="Paragraph" isCode="true" />
   <Style index="10" name="Normal" font="Calibri" fontColor="Black" fontSize="11.0" spaceBefore="0.0" spaceAfter="0.0" applyColors="true" styleType="Paragraph" />
   <Style index="11" name="Strong" font="Calibri" fontColor="Black" fontSize="11.0" bold="true" spaceBefore="0.0" spaceAfter="0.0" applyColors="true" styleType="Character" />
   <Style index="12" name="Emphasis" font="Calibri" fontColor="#4F81BD" fontSize="11.0" bold="true" italic="true" spaceBefore="0.0" spaceAfter="0.0" applyColors="true" styleType="Character" />

--- a/Themes/Red.xml
+++ b/Themes/Red.xml
@@ -6,7 +6,7 @@
   <Style index="3" name="Heading 4" font="Calibri Light" fontColor="#C85A14" fontSize="14.0" italic="true" spaceBefore="0.0" spaceAfter="0.0" spacing="0.0" applyColors="true" styleType="Heading" />
   <Style index="4" name="Heading 5" font="Calibri Light" fontColor="#B43512" fontSize="12.0" italic="true" spaceBefore="0.0" spaceAfter="0.0" spacing="0.0" applyColors="true" styleType="Heading" />
   <Style index="5" name="Heading 6" font="Calibri" fontColor="#B43512" fontSize="12.0" italic="true" spaceBefore="0.0" spaceAfter="0.0" spacing="0.0" applyColors="true" styleType="Heading" />
-  <Style index="6" name="Code" font="Lucida Console" fontColor="#000000" fontSize="10.0" spaceBefore="0.0" spaceAfter="0.0" spacing="0.0" applyColors="false" styleType="Paragraph" />
+  <Style index="6" name="Code" font="Lucida Console" fontColor="#000000" fontSize="10.0" spaceBefore="0.0" spaceAfter="0.0" spacing="0.0" applyColors="false" styleType="Paragraph" isCode="true" />
   <Style index="7" name="Inline Code" font="Lucida Console" fontColor="#000000" highlightColor="#F1F1F1" fontSize="10.0" spaceBefore="0.0" spaceAfter="0.0" spacing="0.0" applyColors="true" styleType="Character" />
   <Style index="8" name="Page Title" font="Calibri Light" fontColor="#464646" fontSize="20.0" spaceBefore="0.0" spaceAfter="0.0" spacing="0.0" applyColors="true" styleType="Paragraph" />
   <Style index="9" name="Citation" font="Calibri" fontColor="#595959" fontSize="9.5" spaceBefore="0.0" spaceAfter="0.0" spacing="0.0" applyColors="true" styleType="Paragraph" />

--- a/Themes/Standard.xml
+++ b/Themes/Standard.xml
@@ -9,7 +9,7 @@
   <Style index="6" name="Page Title" font="Calibri Light" fontColor="#000000" fontSize="20.0" spaceBefore="0.0" spaceAfter="0.0" applyColors="true" styleType="Paragraph" />
   <Style index="7" name="Citation" font="Calibri" fontColor="#595959" fontSize="9.0" spaceBefore="0.0" spaceAfter="0.0" applyColors="true" styleType="Paragraph" />
   <Style index="8" name="Quote" font="Calibri" fontColor="#595959" fontSize="11.0" spaceBefore="0.0" spaceAfter="0.0" applyColors="true" styleType="Paragraph" italic="true" />
-  <Style index="9" name="Code" font="Consolas" fontColor="Black" fontSize="11.0" spaceBefore="0.0" spaceAfter="0.0" applyColors="false" styleType="Paragraph" />
+  <Style index="9" name="Code" font="Consolas" fontColor="Black" fontSize="11.0" spaceBefore="0.0" spaceAfter="0.0" applyColors="false" styleType="Paragraph" isCode="true" />
   <Style index="10" name="Normal" font="Calibri" fontColor="Black" fontSize="11.0" spaceBefore="0.0" spaceAfter="0.0" applyColors="true" styleType="Paragraph" />
   <Style index="11" name="Strong" font="Calibri" fontColor="Black" fontSize="11.0" bold="true" spaceBefore="0.0" spaceAfter="0.0" applyColors="true" styleType="Character" />
   <Style index="12" name="Emphasis" font="Calibri" fontColor="#4F81BD" fontSize="11.0" bold="true" italic="true" spaceBefore="0.0" spaceAfter="0.0" applyColors="true" styleType="Character" />


### PR DESCRIPTION
## Summary

- Adds an explicit `IsCode` flag to user style records, settable via a new
  "Source code paragraph" checkbox in **Edit Styles**. Resolves the
  name/locale brittleness of identifying a code style.
- **Apply Styles to Page** now preserves the page''s `name="code"`
  QuickStyleDef colors and inline syntax-highlight spans when the matched
  user style is `IsCode`. Inline `Stylizer.Clearing.Gray` replaces the
  previous `Clearing.All` on code paragraphs.
- **Singular apply** (My Styles palette / `Ctrl+Alt+Shift+#` / Quick Style
  palette) now repoints the selected OE''s `quickStyleIndex` to the page''s
  `name="code"` QuickStyleDef when the applied style is `IsCode`, so the
  paragraph keeps its Code classification regardless of what it was
  (heading, normal, cite, blockquote, ...). This fixes the original
  cspotcode repro from the issue.

### Backward compatibility

- `StyleRecord` reader-makes-right: legacy themes that name their code
  style `Code` or `Source Code` silently migrate to `IsCode=true` on
  first read. On next save the attribute is persisted (writer-makes-right
  falls out).
- Bundled themes (`OneMore/Styles/DefaultStyles.xml` + the eight files
  under `Themes/`) are marked `isCode="true"` explicitly.
- `ApplyStylesCommand.FindStyle("code")` still falls back to the legacy
  name lookup after the `IsCode` match, so unmigrated themes keep working.

Relates to #1543.

## Test plan

- [ ] **Bug A — color stomp:** Apply Styles to Page on a page with a
  native OneNote code paragraph; confirm the page''s
  `<one:QuickStyleDef name="code">` keeps its existing `fontColor` and
  `highlightColor` instead of being overwritten by the user''s Code style.
- [ ] **Bug B — inline color stripped:** Color one word inside a code
  paragraph red; Apply Styles to Page; confirm the
  `<span style="color:#FF0000">` survives.
- [ ] **Backward compat:** Load an old custom theme (no `isCode` attr,
  Code style named `Code`); Apply Styles to Page works via the name
  fallback. Open Edit Styles → the migrated `IsCode` checkbox shows
  checked.
- [ ] **Regression — other styles:** Apply Styles to Page on a page
  mixing H1 / Quote / Citation / Normal renders identically to `main`.
- [ ] **Round-trip:** Toggle "Source code paragraph" → save → reopen
  Edit Styles → checkbox state persists; resx round-trips `isCode="true"`.
- [ ] **Singular apply on heading:** Heading 1 paragraph + apply Code My
  Style → OE''s `quickStyleIndex` now references `name="code"`; paragraph
  no longer appears in TOC.
- [ ] **Singular apply on `p`:** Normal paragraph + apply Code My Style
  → OE references `name="code"`, not `name="p"`. Subsequent Apply Styles
  to Page does NOT strip the monospace font.