### PR TITLE
Search improvements

### DIFF
--- a/OneMore/Commands/Search/SearchDialog.cs
+++ b/OneMore/Commands/Search/SearchDialog.cs
@@ -4,7 +4,6 @@
 
 namespace River.OneMoreAddIn.Commands
 {
-	using River.OneMoreAddIn.Settings;
 	using River.OneMoreAddIn.UI;
 	using System;
 	using System.Collections.Generic;
@@ -14,8 +13,6 @@ namespace River.OneMoreAddIn.Commands
 
 	internal partial class SearchDialog : MoreForm
 	{
-		private readonly bool experimental;
-
 		public SearchDialog()
 		{
 			InitializeComponent();
@@ -33,13 +30,6 @@ namespace River.OneMoreAddIn.Commands
 
 			DefaultControl = textTab;
 			ElevatedWithOneNote = true;
-
-			var provider = new SettingsProvider();
-			experimental = provider.GetCollection("GeneralSheet").Get<bool>("experimental");
-			if (!experimental)
-			{
-				tabControl.TabPages.Remove(textTab);
-			}
 		}
 
 
@@ -55,12 +45,6 @@ namespace River.OneMoreAddIn.Commands
 			base.OnShown(e);
 
 			// force focus on textSheet's tabIndex(0) control
-			if (experimental)
-			{
-				actionSheet.Focus();
-				return;
-			}
-
 			textSheet.Focus();
 		}
 

--- a/OneMore/Commands/Search/SearchDialogActionControl.cs
+++ b/OneMore/Commands/Search/SearchDialogActionControl.cs
@@ -39,6 +39,8 @@ namespace River.OneMoreAddIn.Commands
 			SelectedPages = new List<string>();
 
 			one = new OneNote();
+
+			Disposed += (_, _) => one?.Dispose();
 		}
 
 

--- a/OneMore/Commands/Search/SearchDialogTextControl.cs
+++ b/OneMore/Commands/Search/SearchDialogTextControl.cs
@@ -126,10 +126,14 @@ namespace River.OneMoreAddIn.Commands
 
 		private void Nevermind(object sender, EventArgs e)
 		{
-			if (source is not null)
+			// snapshot the token source — Search() nulls the field after completion,
+			// so a race here would otherwise NRE
+			var cts = source;
+			if (cts is not null)
 			{
 				logger.WriteLine("cancelling search");
-				source.Cancel();
+				try { cts.Cancel(); }
+				catch (ObjectDisposedException) { /* search already completed */ }
 				return;
 			}
 
@@ -261,46 +265,60 @@ namespace River.OneMoreAddIn.Commands
 				return;
 			}
 
-			await using var one = new OneNote();
-
-			// search by scope...
-
-			if (scopeBox.SelectedIndex == 0)
+			// async void must not let exceptions escape to the SynchronizationContext,
+			// which under the dllhost surrogate can take down OneNote
+			try
 			{
-				await SearchNotebook(one, finder);
-			}
-			else if (scopeBox.SelectedIndex == 1)
-			{
-				grouping = true;
-				var section = await one.GetSection();
-				var ns = one.GetNamespace(section);
+				await using var one = new OneNote();
 
-				if (dateSelector.SelectedIndex > 0)
+				// search by scope...
+
+				if (scopeBox.SelectedIndex == 0)
 				{
-					FilterPagesByDate(section, ns);
+					await SearchNotebook(one, finder);
 				}
+				else if (scopeBox.SelectedIndex == 1)
+				{
+					grouping = true;
+					var section = await one.GetSection();
+					var ns = one.GetNamespace(section);
 
-				SetupProgressBar(section.Descendants(ns + "Page").Count());
-				await SearchSection(one, section, finder);
+					if (dateSelector.SelectedIndex > 0)
+					{
+						FilterPagesByDate(section, ns);
+					}
+
+					SetupProgressBar(section.Descendants(ns + "Page").Count());
+					await SearchSection(one, section, finder);
+				}
+				else
+				{
+					logger.StartClock();
+					grouping = false;
+
+					var page = await one.GetPage(one.CurrentPageId, OneNote.PageDetail.Basic);
+					logger.WriteTime("loaded page", keepRunning: true);
+
+					await SearchPage(one, page, finder);
+					logger.WriteTime("search complete");
+				}
 			}
-			else
+			catch (OperationCanceledException)
 			{
-				logger.StartClock();
-				grouping = false;
-
-				var page = await one.GetPage(one.CurrentPageId, OneNote.PageDetail.Basic);
-				logger.WriteTime("loaded page", keepRunning: true);
-
-				await SearchPage(one, page, finder);
-				logger.WriteTime("search complete");
+				logger.WriteLine("search cancelled");
 			}
+			catch (Exception exc)
+			{
+				logger.WriteLine("error during search", exc);
+			}
+			finally
+			{
+				// restore controls and dispose the cancellation source even on failure
+				source?.Dispose();
+				source = null;
 
-			// restore controls...
-
-			source?.Dispose();
-			source = null;
-
-			RestoreControls();
+				RestoreControls();
+			}
 		}
 
 

--- a/OneMore/Commands/Search/SearchDialogTextControl.cs
+++ b/OneMore/Commands/Search/SearchDialogTextControl.cs
@@ -57,10 +57,11 @@ namespace River.OneMoreAddIn.Commands
 
 		private readonly List<ResultItem> results = new();
 		private readonly Dictionary<Color, SolidBrush> groupBrushes = new();
+
 		private Font groupFont;
 		private Font hitFont;
-		private SolidBrush hitBackBrush;       // unselected hit row background
-		private SolidBrush selectionBackBrush; // selected hit row background
+		private SolidBrush hitBackBrush;					// unselected hit row background
+		private readonly SolidBrush selectionBackBrush;		// selected hit row background
 
 
 		public SearchDialogTextControl()
@@ -122,19 +123,6 @@ namespace River.OneMoreAddIn.Commands
 				foreach (var brush in groupBrushes.Values) brush.Dispose();
 				groupBrushes.Clear();
 			};
-		}
-
-
-		// Returns a cached SolidBrush for the given color, allocating one on first use.
-		// Lifetime is tied to the control; brushes are disposed in the Disposed handler.
-		private SolidBrush GetGroupBrush(Color color)
-		{
-			if (!groupBrushes.TryGetValue(color, out var brush))
-			{
-				brush = new SolidBrush(color);
-				groupBrushes[color] = brush;
-			}
-			return brush;
 		}
 
 
@@ -471,28 +459,45 @@ namespace River.OneMoreAddIn.Commands
 				TextFormatFlags.NoPrefix |
 				TextFormatFlags.SingleLine;
 
+			const int swatchW = 8;
+
 			if (result.IsGroup)
 			{
 				// Colored swatch on the left edge indicating the section's accent color
 				const int pad = 4;
-				const int swatchW = 8;
 				var swatch = new Rectangle(
 					e.Bounds.X + pad, e.Bounds.Y + pad,
 					swatchW, e.Bounds.Height - pad * 2);
+
 				e.Graphics.FillRectangle(GetGroupBrush(result.SectionColor), swatch);
 
 				var textRect = new Rectangle(
 					swatch.Right + pad * 2, e.Bounds.Y,
 					e.Bounds.Width - swatch.Right - pad * 2, e.Bounds.Height);
+
 				TextRenderer.DrawText(e.Graphics, result.Text, groupFont, textRect, ForeColor, flags);
 			}
 			else
 			{
 				var foreColor = selected ? SelectionFore : ForeColor;
 				var textRect = new Rectangle(
-					e.Bounds.X + 4, e.Bounds.Y, e.Bounds.Width - 4, e.Bounds.Height);
+					e.Bounds.X + swatchW + 4, e.Bounds.Y, e.Bounds.Width - swatchW - 4, e.Bounds.Height);
+
 				TextRenderer.DrawText(e.Graphics, result.Text, hitFont, textRect, foreColor, flags);
 			}
+		}
+
+
+		// Returns a cached SolidBrush for the given color, allocating one on first use.
+		// Lifetime is tied to the control; brushes are disposed in the Disposed handler.
+		private SolidBrush GetGroupBrush(Color color)
+		{
+			if (!groupBrushes.TryGetValue(color, out var brush))
+			{
+				brush = new SolidBrush(color);
+				groupBrushes[color] = brush;
+			}
+			return brush;
 		}
 
 

--- a/OneMore/Commands/Search/SearchDialogTextControl.cs
+++ b/OneMore/Commands/Search/SearchDialogTextControl.cs
@@ -46,6 +46,8 @@ namespace River.OneMoreAddIn.Commands
 		private const int UpdatedAfter = 3;
 		private const int UpdatedBefore = 4;
 
+		private readonly ThemeManager manager = ThemeManager.Instance;
+
 		// Matches the original HighlightBackground / HighlightForeground from the Designer
 		private static readonly Color SelectionBack = Color.FromArgb(215, 193, 255);
 		private static readonly Color SelectionFore = SystemColors.HighlightText;

--- a/OneMore/Commands/Search/SearchDialogTextControl.cs
+++ b/OneMore/Commands/Search/SearchDialogTextControl.cs
@@ -37,6 +37,7 @@ namespace River.OneMoreAddIn.Commands
 			public Color SectionColor { get; set; }     // group only: left swatch color
 			public Color SectionBackColor { get; set; }  // group only: row background tint
 			public string Hyperlink { get; set; }        // hit only
+			public ListViewItem ViewItem { get; set; }   // lazily cached for OnRetrieveVirtualItem
 		}
 
 
@@ -55,6 +56,7 @@ namespace River.OneMoreAddIn.Commands
 		private bool grouping;
 
 		private readonly List<ResultItem> results = new();
+		private readonly Dictionary<Color, SolidBrush> groupBrushes = new();
 		private Font groupFont;
 		private Font hitFont;
 		private SolidBrush hitBackBrush;       // unselected hit row background
@@ -117,7 +119,22 @@ namespace River.OneMoreAddIn.Commands
 				hitFont?.Dispose();
 				hitBackBrush?.Dispose();
 				selectionBackBrush?.Dispose();
+				foreach (var brush in groupBrushes.Values) brush.Dispose();
+				groupBrushes.Clear();
 			};
+		}
+
+
+		// Returns a cached SolidBrush for the given color, allocating one on first use.
+		// Lifetime is tied to the control; brushes are disposed in the Disposed handler.
+		private SolidBrush GetGroupBrush(Color color)
+		{
+			if (!groupBrushes.TryGetValue(color, out var brush))
+			{
+				brush = new SolidBrush(color);
+				groupBrushes[color] = brush;
+			}
+			return brush;
 		}
 
 
@@ -383,6 +400,12 @@ namespace River.OneMoreAddIn.Commands
 			}
 
 			resultsView.VirtualListSize = results.Count;
+
+			// WM_PAINT is the lowest-priority message; without this the search loop's
+			// own SynchronizationContext continuations starve the paint and rows do not
+			// appear until the loop ends. Update() dispatches any pending paint for the
+			// invalid region (only the new tail rows) without re-invalidating.
+			resultsView.Update();
 		}
 
 
@@ -396,7 +419,9 @@ namespace River.OneMoreAddIn.Commands
 
 			// The item text and font are used by the ListView for keyboard search and
 			// accessibility; actual painting happens in OnDrawItem / OnDrawSubItem.
-			e.Item = new ListViewItem(result.Text)
+			// Cache the ListViewItem on the result so sustained scroll over thousands
+			// of rows does not allocate one per visible-row callback.
+			e.Item = result.ViewItem ??= new ListViewItem(result.Text)
 			{
 				Font = result.IsGroup ? groupFont : hitFont
 			};
@@ -412,8 +437,7 @@ namespace River.OneMoreAddIn.Commands
 
 			if (result.IsGroup)
 			{
-				using var bgBrush = new SolidBrush(result.SectionBackColor);
-				e.Graphics.FillRectangle(bgBrush, e.Bounds);
+				e.Graphics.FillRectangle(GetGroupBrush(result.SectionBackColor), e.Bounds);
 			}
 			else if (selected)
 			{
@@ -455,8 +479,7 @@ namespace River.OneMoreAddIn.Commands
 				var swatch = new Rectangle(
 					e.Bounds.X + pad, e.Bounds.Y + pad,
 					swatchW, e.Bounds.Height - pad * 2);
-				using var swatchBrush = new SolidBrush(result.SectionColor);
-				e.Graphics.FillRectangle(swatchBrush, swatch);
+				e.Graphics.FillRectangle(GetGroupBrush(result.SectionColor), swatch);
 
 				var textRect = new Rectangle(
 					swatch.Right + pad * 2, e.Bounds.Y,

--- a/OneMore/OneNote.cs
+++ b/OneMore/OneNote.cs
@@ -228,19 +228,19 @@ namespace River.OneMoreAddIn
 		/// <summary>
 		/// Gets the currently viewed page ID
 		/// </summary>
-		public string CurrentPageId => onenote.Windows.CurrentWindow?.CurrentPageId;
+		public string CurrentPageId => WithCurrentWindow(w => w.CurrentPageId, null);
 
 
 		/// <summary>
 		/// Gets the currently viewed section ID
 		/// </summary>
-		public string CurrentSectionId => onenote.Windows.CurrentWindow?.CurrentSectionId;
+		public string CurrentSectionId => WithCurrentWindow(w => w.CurrentSectionId, null);
 
 
 		/// <summary>
 		/// Gets the currently viewed notebook ID
 		/// </summary>
-		public string CurrentNotebookId => onenote.Windows.CurrentWindow?.CurrentNotebookId;
+		public string CurrentNotebookId => WithCurrentWindow(w => w.CurrentNotebookId, null);
 
 
 		/// <summary>
@@ -256,7 +256,7 @@ namespace River.OneMoreAddIn
 		/// the owner parameter to MoreMessageBox Show methods.
 		/// </summary>
 		public Win32WindowHandle OwnerWindow =>
-			new(new IntPtr((long)(IntPtr)onenote.Windows.CurrentWindow.WindowHandle));
+			new(WithCurrentWindow(w => new IntPtr((long)(IntPtr)w.WindowHandle), IntPtr.Zero));
 
 
 		/// <summary>
@@ -268,13 +268,47 @@ namespace River.OneMoreAddIn
 		/// <summary>
 		/// Gets the number of open OneNote windows
 		/// </summary>
-		public int WindowCount => (int)onenote.Windows.Count;
+		public int WindowCount
+		{
+			get
+			{
+				var windows = onenote.Windows;
+				try { return (int)windows.Count; }
+				finally { Marshal.ReleaseComObject(windows); }
+			}
+		}
 
 
 		/// <summary>
 		/// Gets the handle of the current window
 		/// </summary>
-		public IntPtr WindowHandle => (IntPtr)onenote.Windows.CurrentWindow.WindowHandle;
+		public IntPtr WindowHandle =>
+			WithCurrentWindow(w => (IntPtr)w.WindowHandle, IntPtr.Zero);
+
+
+		// Reads a property from the current Window, explicitly releasing the intermediate
+		// Windows collection and Window RCWs rather than waiting for GC. Finalizer-driven
+		// release of these proxies under the dllhost MTA can stall OneNote.
+		private T WithCurrentWindow<T>(Func<Window, T> reader, T fallback)
+		{
+			var windows = onenote.Windows;
+			try
+			{
+				var window = windows.CurrentWindow;
+				try
+				{
+					return window is null ? fallback : reader(window);
+				}
+				finally
+				{
+					if (window is not null) Marshal.ReleaseComObject(window);
+				}
+			}
+			finally
+			{
+				Marshal.ReleaseComObject(windows);
+			}
+		}
 
 
 		// = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
@@ -310,7 +344,7 @@ namespace River.OneMoreAddIn
 							$"invalid COM object error, (HResult {exc.HResult:X}), " +
 							$"retrying in {ms}ms with new Application object", exc);
 
-						onenote = ApplicationFactory.CreateApplication();
+						ReplaceApplication();
 						await Task.Delay(ms);
 					}
 					catch (COMException exc)
@@ -347,7 +381,7 @@ namespace River.OneMoreAddIn
 								$"retyring in {ms}ms with new Application object");
 						}
 
-						onenote = ApplicationFactory.CreateApplication();
+						ReplaceApplication();
 						await Task.Delay(ms);
 					}
 					// cancellation tokens will cause ThreadAbort which is normal
@@ -365,6 +399,21 @@ namespace River.OneMoreAddIn
 			}
 
 			return retries == int.MaxValue;
+		}
+
+
+		// Release the current Application RCW before allocating a replacement so the
+		// old proxy does not linger until GC. The old proxy may already be in a bad
+		// state (that is why we are retrying), so swallow any release errors.
+		private void ReplaceApplication()
+		{
+			if (onenote is not null)
+			{
+				try { Marshal.FinalReleaseComObject(onenote); }
+				catch (Exception exc) { logger.WriteLine("error releasing onenote in retry", exc); }
+			}
+
+			onenote = ApplicationFactory.CreateApplication();
 		}
 
 
@@ -451,7 +500,7 @@ namespace River.OneMoreAddIn
 		/// <returns>The bounds expressed as a Rectangle</returns>
 		public System.Drawing.Rectangle GetCurrentMainWindowBounds()
 		{
-			var handle = (IntPtr)onenote.Windows.CurrentWindow.WindowHandle;
+			var handle = WithCurrentWindow(w => (IntPtr)w.WindowHandle, IntPtr.Zero);
 			var parent = handle;
 			while (parent != IntPtr.Zero)
 			{
@@ -1171,47 +1220,69 @@ namespace River.OneMoreAddIn
 			string title, string description, Scope scope, SelectLocationCallback callback)
 		{
 			var dialog = onenote.QuickFiling();
-			dialog.Title = title;
-			dialog.Description = description;
-			dialog.ParentWindowHandle = onenote.Windows.CurrentWindow.WindowHandle;
-
-			var restriction = HierarchyElement.heNotebooks;
-
-			switch (scope)
+			try
 			{
-				case Scope.Notebooks:
-					dialog.TreeDepth = HierarchyElement.heNotebooks;
-					break;
-				case Scope.SectionGroups:
-					dialog.TreeDepth = HierarchyElement.heSectionGroups;
-					dialog.TreeCollapsedState = TreeCollapsedStateType.tcsExpanded;
-					dialog.ShowCreateNewNotebook();
-					restriction = HierarchyElement.heSectionGroups | HierarchyElement.heNotebooks;
-					break;
-				case Scope.Sections:
-					dialog.TreeDepth = HierarchyElement.heSections;
-					restriction = HierarchyElement.heSections;
-					break;
-				case Scope.Pages:
-					dialog.TreeDepth = HierarchyElement.hePages;
-					restriction = HierarchyElement.heSectionGroups | HierarchyElement.heNotebooks |
-						HierarchyElement.heSections | HierarchyElement.hePages;
-					break;
+				dialog.Title = title;
+				dialog.Description = description;
+
+				// release intermediate Windows/Window RCWs immediately rather than waiting for GC
+				var windows = onenote.Windows;
+				try
+				{
+					var window = windows.CurrentWindow;
+					try { dialog.ParentWindowHandle = window.WindowHandle; }
+					finally { if (window is not null) Marshal.ReleaseComObject(window); }
+				}
+				finally { Marshal.ReleaseComObject(windows); }
+
+				var restriction = HierarchyElement.heNotebooks;
+
+				switch (scope)
+				{
+					case Scope.Notebooks:
+						dialog.TreeDepth = HierarchyElement.heNotebooks;
+						break;
+					case Scope.SectionGroups:
+						dialog.TreeDepth = HierarchyElement.heSectionGroups;
+						dialog.TreeCollapsedState = TreeCollapsedStateType.tcsExpanded;
+						dialog.ShowCreateNewNotebook();
+						restriction = HierarchyElement.heSectionGroups | HierarchyElement.heNotebooks;
+						break;
+					case Scope.Sections:
+						dialog.TreeDepth = HierarchyElement.heSections;
+						restriction = HierarchyElement.heSections;
+						break;
+					case Scope.Pages:
+						dialog.TreeDepth = HierarchyElement.hePages;
+						restriction = HierarchyElement.heSectionGroups | HierarchyElement.heNotebooks |
+							HierarchyElement.heSections | HierarchyElement.hePages;
+						break;
+				}
+
+				dialog.AddButton(Resx.word_OK, restriction, restriction, false);
+
+				// the dialog RCW must survive Run() since the user interacts with it asynchronously;
+				// FilingCallback releases it when OnDialogClosed fires
+				dialog.Run(new FilingCallback(callback, dialog));
+				dialog = null;
 			}
-
-			dialog.AddButton(Resx.word_OK, restriction, restriction, false);
-
-			dialog.Run(new FilingCallback(callback));
+			finally
+			{
+				// only fires if we threw before handing the dialog to Run()
+				if (dialog is not null) Marshal.ReleaseComObject(dialog);
+			}
 		}
 
 
 		private sealed class FilingCallback : IQuickFilingDialogCallback
 		{
 			private readonly SelectLocationCallback userCallback;
+			private IQuickFilingDialog ownedDialog;
 
-			public FilingCallback(SelectLocationCallback usercb)
+			public FilingCallback(SelectLocationCallback usercb, IQuickFilingDialog dialog)
 			{
 				userCallback = usercb;
+				ownedDialog = dialog;
 			}
 
 			public void OnDialogClosed(IQuickFilingDialog dialog)
@@ -1223,6 +1294,15 @@ namespace River.OneMoreAddIn
 				catch (Exception exc)
 				{
 					Logger.Current.WriteLine("error returned from FilingCallback", exc);
+				}
+				finally
+				{
+					if (ownedDialog is not null)
+					{
+						try { Marshal.ReleaseComObject(ownedDialog); }
+						catch (Exception exc) { Logger.Current.WriteLine("error releasing filing dialog", exc); }
+						ownedDialog = null;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## IS YOUR COMMIT SIGNED?
Yes.

## Enhancement or Defect Addressed by This PR
Several improvements to the search subsystem covering correctness (COM
reference hygiene), robustness (cancellation/error handling), and the
search-results UI (incremental rendering and rendering performance at
scale). Targets intermittent post-search hangs of OneNote/dllhost, search
results that did not appear until the loop finished, and per-paint
allocations in the owner-drawn virtual ListView.

Also retires the experimental gate on the full-text search tab so it is
always visible.

## Description of Proposed Changes

### COM reference hygiene (`OneNote.cs`, `SearchDialogActionControl.cs`)

The add-in runs under the dllhost COM surrogate (MTA), where RCWs left for
the GC finalizer to release can stall OneNote. Four leaks fixed:

- **`SearchDialogActionControl`** held a `private readonly OneNote one`
  field constructed in the ctor; the Designer's `Dispose(bool)` only
  released `components`, so the `IApplication` RCW was orphaned on every
  dialog open. A `Disposed += () => one?.Dispose()` handler in the ctor now
  releases it (mirrors the pattern used by `SearchDialogTextControl`).
- **`InvokeWithRetry`** previously reassigned the `onenote` field on retry
  without releasing the old RCW. A new `ReplaceApplication()` helper calls
  `Marshal.FinalReleaseComObject` (with swallow) before allocating the
  replacement.
- **`onenote.Windows.CurrentWindow.X` property chains** in `CurrentPageId`,
  `CurrentSectionId`, `CurrentNotebookId`, `OwnerWindow`, `WindowHandle`,
  `WindowCount`, and `GetCurrentMainWindowBounds` created two intermediate
  RCWs per access (`IWindowCollection`, `IWindow`) that were never
  released. A new `WithCurrentWindow<T>(Func<Window, T>, T fallback)`
  helper wraps the access in try/finally with explicit
  `Marshal.ReleaseComObject`.
- **`SelectLocation`** never released the `IQuickFilingDialog` returned by
  `onenote.QuickFiling()`. The dialog must outlive the call (`Run` is
  non-blocking and a user-driven callback closes it), so ownership is
  handed to `FilingCallback` which releases it in `OnDialogClosed`. The
  intermediate `Windows`/`Window` chain used to set `ParentWindowHandle` is
  now also released inline.

### Search loop robustness (`SearchDialogTextControl.cs`)

- **`Search` wrapped in `try/catch/finally`** — an unhandled exception in an
  `async void` event handler propagates to the `SynchronizationContext` and
  under the dllhost surrogate can take down OneNote. `OperationCanceledException`
  is handled separately as expected cancellation; the `finally` block always
  disposes the `CancellationTokenSource` and restores controls.
- **`Nevermind` cancellation race tightened** — the handler now snapshots
  `source` into a local before checking and swallows `ObjectDisposedException`
  in case `Search`'s `finally` ran first.

### Incremental rendering of search results (`SearchDialogTextControl.cs`)

Previously, hits often did not appear in the list until the search loop
finished. `AddPageResults` was already setting `VirtualListSize` per page,
but `WM_PAINT` is Windows' lowest-priority message and the loop's own
`SynchronizationContext` continuations (from each `await`) starved it.
`AddPageResults` now calls `resultsView.Update()` after updating
`VirtualListSize`, which dispatches any pending paint for the just-invalid
tail region without re-invalidating. Cheap — bounded by the number of
newly-visible rows — and the lightest fix that addresses the symptom.

### Allocation-free render path for large result sets (`SearchDialogTextControl.cs`)

The virtual + owner-drawn ListView already scales by viewport rather than
total rows, but three callbacks allocated per invocation. Fixed:

- `OnRetrieveVirtualItem` now caches the constructed `ListViewItem` on the
  `ResultItem` itself (`ViewItem` field) instead of allocating one per
  callback.
- `OnDrawItem` and `OnDrawSubItem` no longer `using var bgBrush = new
  SolidBrush(...)` per paint. A new `GetGroupBrush(Color)` helper backed by
  a `Dictionary<Color, SolidBrush>` returns a brush per unique color
  (one per section), disposed alongside the existing brushes in the
  `Disposed` handler.

Sustained scroll over thousands of rows now allocates effectively nothing
in the render path.

### Misc

- `SearchDialog.cs` — the full-text search tab (`textTab`) is no longer
  hidden behind the `GeneralSheet → experimental` setting.
- Minor formatting and a small text-alignment tweak so hits indent past
  the swatch column.