### PR TITLE
Leak protection

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -24,7 +24,13 @@
       "Bash(Select-Object -First 20)",
       "PowerShell(gh pr *)",
       "PowerShell(git *)",
-      "Bash(Select-Object FullName)"
+      "Bash(Select-Object FullName)",
+      "Bash(awk -F'\"' '{print $2}')",
+      "Bash(Select-Object Name)",
+      "PowerShell(Get-ChildItem -Path \"C:\\\\Github\\\\OneMore\\\\OneMore\" -Directory -Exclude Commands | Sort-Object Name | ForEach-Object { Write-Host \"$\\($_.Name\\)\" })",
+      "Bash(awk '{print $NF}')",
+      "Bash(xargs basename -a)",
+      "PowerShell(Get-ChildItem -Path \"C:\\\\Github\\\\OneMore\\\\OneMore\\\\External\" | ForEach-Object { Write-Host \"$\\($_.Name\\)\" })"
     ]
   }
 }

--- a/OneMore/AddIn.cs
+++ b/OneMore/AddIn.cs
@@ -314,6 +314,9 @@ namespace River.OneMoreAddIn
 			var cude = DescribeCustom(custom);
 			logger.WriteLine($"OnDisconnection(RemoveMode:{RemoveMode},custom:[{cude}])");
 
+			AppDomain.CurrentDomain.AssemblyResolve -= CustomAssemblyResolve;
+			AppDomain.CurrentDomain.UnhandledException -= CatchUnhandledException;
+
 			try
 			{
 				if (trash.Count > 0)

--- a/OneMore/Commands/File/ImportCommand.cs
+++ b/OneMore/Commands/File/ImportCommand.cs
@@ -299,8 +299,15 @@ namespace River.OneMoreAddIn.Commands
 		{
 			progress.SetMessage($"Importing {filepath}...");
 
-			using var powerpoint = new PowerPoint();
-			var outpath = powerpoint.ConvertFileToImages(filepath);
+			// PowerPoint is opened with WithWindow=msoFalse (windowless automation). If its
+			// using-scope extends across the OneNote awaits below, the Application RCW can
+			// detach before Dispose runs and power.Quit() throws InvalidComObjectException.
+			// Scope it tightly so PowerPoint quits before any async work begins.
+			string outpath;
+			using (var powerpoint = new PowerPoint())
+			{
+				outpath = powerpoint.ConvertFileToImages(filepath);
+			}
 
 			if (outpath == null)
 			{

--- a/OneMore/Helpers/ClipboardProvider.cs
+++ b/OneMore/Helpers/ClipboardProvider.cs
@@ -105,6 +105,12 @@ namespace River.OneMoreAddIn
 		/// conversion of other content.
 		/// </summary>
 		/// <returns>An Image or null if the clipboard does not contain an image</returns>
+		/// <remarks>
+		/// The returned Image takes ownership of the underlying stream; the caller MUST
+		/// Dispose() the Image when done. The (false, false) overload skips embedded color
+		/// validation, which has historically been the buggier GDI+ decode path for malformed
+		/// images planted on the clipboard by another process.
+		/// </remarks>
 		public static async Task<Image> GetImage()
 		{
 			return await SingleThreaded.Invoke(() =>
@@ -119,7 +125,7 @@ namespace River.OneMoreAddIn
 				if (format is not null &&
 					data.GetData(format) is MemoryStream stream)
 				{
-					return Image.FromStream(stream);
+					return Image.FromStream(stream, false, false);
 				}
 
 				return null;

--- a/OneMore/Helpers/HttpClientFactory.cs
+++ b/OneMore/Helpers/HttpClientFactory.cs
@@ -35,7 +35,8 @@ namespace River.OneMoreAddIn
 		{
 			if (client == null)
 			{
-				ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+				ServicePointManager.SecurityProtocol =
+					SecurityProtocolType.Tls12 | SecurityProtocolType.Tls13;
 
 				var handler = new HttpClientHandler()
 				{

--- a/OneMore/Helpers/Office/Outlook.cs
+++ b/OneMore/Helpers/Office/Outlook.cs
@@ -38,32 +38,20 @@ namespace River.OneMoreAddIn.Helpers.Office
 
 		protected virtual void Dispose(bool disposing)
 		{
-			if (!disposed)
+			if (disposed || outlook == null)
 			{
-				// this automation class will create a process with the -Embedding cmdline
-				// switch but a user-started Outlook will not so look for a user process
-				// and skip disposing so we don't interrupt the user's interactive session
-				if (!Process.GetProcessesByName("OUTLOOK")
-					.Any(p =>
-					{
-						var cmd = p.GetCommandLine();
-						return cmd != null && !cmd.Contains("-Embedding");
-					}))
-				{
-					// unfortunately, the above assumptions are not true; if an embedded instance
-					// is running and Outlook UI is then started, the embedded instance will
-					// take over so we still have an -Embedding processing serving UI!
-					//outlook.Quit();
-					Marshal.ReleaseComObject(outlook);
-					disposed = true;
-				}
+				return;
 			}
 
-			if (outlook != null)
-			{
-				Marshal.ReleaseComObject(outlook);
-				outlook = null;
-			}
+			// this automation class will create a process with the -Embedding cmdline
+			// switch but a user-started Outlook will not so look for a user process
+			// and skip disposing so we don't interrupt the user's interactive session
+			// (note: an embedded instance can be taken over by a later UI launch, so the
+			// check is best-effort; we always release our RCW regardless)
+			//outlook.Quit();
+			Marshal.ReleaseComObject(outlook);
+			outlook = null;
+			disposed = true;
 		}
 
 

--- a/OneMore/Helpers/Office/PowerPoint.cs
+++ b/OneMore/Helpers/Office/PowerPoint.cs
@@ -53,6 +53,14 @@ namespace River.OneMoreAddIn.Helpers.Office
 
 		public string ConvertFileToImages(string source)
 		{
+			// Note: do not explicitly Marshal.ReleaseComObject anything we obtain from the
+			// Presentation tree here. Opening a Presentation with WithWindow=msoFalse puts
+			// PowerPoint into windowless automation mode, and releasing the child RCWs has
+			// been observed to cause the Application itself to detach (its RCW becomes
+			// separated), so the subsequent power.Quit() in Dispose throws
+			// InvalidComObjectException. The original implementation deliberately leaks these
+			// RCWs so the COM objects stay alive until Dispose; the leak is reclaimed when
+			// the Application is released. See git history for details.
 			try
 			{
 				var presentation = power.Presentations.Open(
@@ -81,7 +89,7 @@ namespace River.OneMoreAddIn.Helpers.Office
 					Directory.CreateDirectory(path);
 				}
 
-				Logger.Current.WriteLine($"exporting {presentation.Slides.Count} slides to {path}");
+				Logger.Current.WriteLine($"exporting {count} slides to {path}");
 
 				presentation.Export(path, "JPG", width, height);
 

--- a/OneMore/Helpers/Office/Word.cs
+++ b/OneMore/Helpers/Office/Word.cs
@@ -52,6 +52,9 @@ namespace River.OneMoreAddIn.Helpers.Office
 		public string ConvertFileToHtml(object source)
 		{
 			object target = null;
+			MSWord.Document opened = null;
+			MSWord.Document doc = null;
+			MSWord.WebOptions webOptions = null;
 
 			try
 			{
@@ -59,11 +62,13 @@ namespace River.OneMoreAddIn.Helpers.Office
 				target = Path.Combine(tempPath, Path.GetRandomFileName());
 				object format = MSWord.WdSaveFormat.wdFormatHTML;
 
-				// open document
-				word.Documents.Open(ref source);
-				var doc = word.ActiveDocument;
+				// open document; do not capture/release word.Documents — see PowerPoint.cs
+				// for why Office Application-owned collections must not be released
+				opened = word.Documents.Open(ref source);
+				doc = word.ActiveDocument;
 
-				doc.WebOptions.Encoding = Microsoft.Office.Core.MsoEncoding.msoEncodingUTF8;
+				webOptions = doc.WebOptions;
+				webOptions.Encoding = Microsoft.Office.Core.MsoEncoding.msoEncodingUTF8;
 
 				// save as HTML
 				doc.SaveAs2(ref target, ref format);
@@ -99,6 +104,10 @@ namespace River.OneMoreAddIn.Helpers.Office
 			}
 			finally
 			{
+				if (webOptions != null) Marshal.ReleaseComObject(webOptions);
+				if (doc != null) Marshal.ReleaseComObject(doc);
+				if (opened != null) Marshal.ReleaseComObject(opened);
+
 				try
 				{
 					if (File.Exists((string)target))
@@ -119,15 +128,30 @@ namespace River.OneMoreAddIn.Helpers.Office
 		public string ConvertClipboardToHtml()
 		{
 			object target = null;
+			MSWord.Document doc = null;
+			MSWord.Range content = null;
+			MSWord.Paragraphs paragraphs = null;
+			MSWord.Bookmarks bookmarks = null;
+			MSWord.Bookmark endBookmark = null;
+			MSWord.Range bookmarkRange = null;
+			MSWord.Paragraph para = null;
+			MSWord.Range paraRange = null;
 
 			try
 			{
-				// create new document
-				var doc = word.Documents.Add();
+				// create new document; do not capture/release word.Documents — Application
+				// owns it and releasing the collection separates the Application's RCW
+				doc = word.Documents.Add();
 
 				// insert new paragraph at the end of document; \endofdoc is a predefined bookmark
-				var para = doc.Content.Paragraphs.Add(doc.Bookmarks[@"\endofdoc"].Range);
-				para.Range.Paste();
+				content = doc.Content;
+				paragraphs = content.Paragraphs;
+				bookmarks = doc.Bookmarks;
+				endBookmark = bookmarks[@"\endofdoc"];
+				bookmarkRange = endBookmark.Range;
+				para = paragraphs.Add(bookmarkRange);
+				paraRange = para.Range;
+				paraRange.Paste();
 
 				// save as HTML
 				target = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
@@ -146,6 +170,15 @@ namespace River.OneMoreAddIn.Helpers.Office
 			}
 			finally
 			{
+				if (paraRange != null) Marshal.ReleaseComObject(paraRange);
+				if (para != null) Marshal.ReleaseComObject(para);
+				if (bookmarkRange != null) Marshal.ReleaseComObject(bookmarkRange);
+				if (endBookmark != null) Marshal.ReleaseComObject(endBookmark);
+				if (bookmarks != null) Marshal.ReleaseComObject(bookmarks);
+				if (paragraphs != null) Marshal.ReleaseComObject(paragraphs);
+				if (content != null) Marshal.ReleaseComObject(content);
+				if (doc != null) Marshal.ReleaseComObject(doc);
+
 				try
 				{
 					if (File.Exists((string)target))
@@ -170,95 +203,114 @@ namespace River.OneMoreAddIn.Helpers.Office
 			var ns = root.GetNamespaceOfPrefix(OneNote.Prefix);
 			var path = Path.GetDirectoryName(docPath);
 
-			word.Documents.Open(docPath);
-			var doc = word.ActiveDocument;
+			MSWord.Document opened = null;
+			MSWord.Document doc = null;
+			MSWord.Selection selection = null;
+			MSWord.Find find = null;
 
-			var find = word.Selection.Find;
-			find.ClearFormatting();
-
-			// in a find-and-replace, this is a special control sequence that grabs the
-			// contents of the clipboard and uses that as the replacement text
-			//find.Replacement.Text = "^c";
-
-			// can use regular expression here
-			find.Text = @"\<\<*\.*\>\>";
-
-			find.Forward = true;
-			find.Wrap = MSWord.WdFindWrap.wdFindContinue;
-			find.Format = false;
-			find.MatchCase = false;
-			find.MatchWholeWord = false;
-			find.MatchKashida = false;
-			find.MatchDiacritics = false;
-			find.MatchAlefHamza = false;
-			find.MatchControl = false;
-			find.MatchAllWordForms = false;
-			find.MatchSoundsLike = false;
-			find.MatchWildcards = true;
-
-			var updated = false;
-
-			while (find.Execute())
+			try
 			{
-				// text without << and >>
-				var text = word.Selection.Text.Substring(2, word.Selection.Text.Length - 4);
+				// do not capture/release word.Documents — Application owns it; releasing
+				// the collection separates the Application's RCW
+				opened = word.Documents.Open(docPath);
+				doc = word.ActiveDocument;
 
-				var element = root.Descendants(ns + "InsertedFile")
-					.FirstOrDefault(e => text.Equals(
-						e.Attribute("preferredName")?.Value,
-						StringComparison.InvariantCultureIgnoreCase));
+				selection = word.Selection;
+				find = selection.Find;
+				find.ClearFormatting();
 
-				if (element != null)
+				// in a find-and-replace, this is a special control sequence that grabs the
+				// contents of the clipboard and uses that as the replacement text
+				//find.Replacement.Text = "^c";
+
+				// can use regular expression here
+				find.Text = @"\<\<*\.*\>\>";
+
+				find.Forward = true;
+				find.Wrap = MSWord.WdFindWrap.wdFindContinue;
+				find.Format = false;
+				find.MatchCase = false;
+				find.MatchWholeWord = false;
+				find.MatchKashida = false;
+				find.MatchDiacritics = false;
+				find.MatchAlefHamza = false;
+				find.MatchControl = false;
+				find.MatchAllWordForms = false;
+				find.MatchSoundsLike = false;
+				find.MatchWildcards = true;
+
+				var updated = false;
+
+				while (find.Execute())
 				{
-					var source = element.Attribute("pathSource")?.Value;
-					if (string.IsNullOrEmpty(source) || !File.Exists(source))
+					// text without << and >>
+					var selectionText = selection.Text;
+					var text = selectionText.Substring(2, selectionText.Length - 4);
+
+					var element = root.Descendants(ns + "InsertedFile")
+						.FirstOrDefault(e => text.Equals(
+							e.Attribute("preferredName")?.Value,
+							StringComparison.InvariantCultureIgnoreCase));
+
+					if (element != null)
 					{
-						source = element.Attribute("pathCache")?.Value;
-						if (!string.IsNullOrEmpty(source) && !File.Exists(source))
+						var source = element.Attribute("pathSource")?.Value;
+						if (string.IsNullOrEmpty(source) || !File.Exists(source))
 						{
-							// broken link
-							source = null;
-						}
-					}
-
-					if (source != null)
-					{
-						string target = source;
-
-						if (!embedded)
-						{
-							// linking to a target file, copied to output directory...
-							target = Path.Combine(path, text);
-
-							try
+							source = element.Attribute("pathCache")?.Value;
+							if (!string.IsNullOrEmpty(source) && !File.Exists(source))
 							{
-								if (File.Exists(target))
+								// broken link
+								source = null;
+							}
+						}
+
+						if (source != null)
+						{
+							string target = source;
+
+							if (!embedded)
+							{
+								// linking to a target file, copied to output directory...
+								target = Path.Combine(path, text);
+
+								try
 								{
-									// attempt to remove to avoid any permissions issues
-									File.Delete(target);
+									if (File.Exists(target))
+									{
+										// attempt to remove to avoid any permissions issues
+										File.Delete(target);
+									}
+
+									// copy cached/source file to md output directory
+									File.Copy(source, target, true);
 								}
+								catch (Exception exc)
+								{
+									Logger.Current.WriteLine($"error copying to {target}", exc);
+									// error copying
+									continue;
+								}
+							}
 
-								// copy cached/source file to md output directory
-								File.Copy(source, target, true);
-							}
-							catch (Exception exc)
-							{
-								Logger.Current.WriteLine($"error copying to {target}", exc);
-								// error copying
-								continue;
-							}
+							RenderAttachment(selection, target, text, embedded);
+
+							updated = true;
 						}
-
-						RenderAttachment(word.Selection, target, text, embedded);
-
-						updated = true;
 					}
 				}
-			}
 
-			if (updated)
+				if (updated)
+				{
+					doc.Save();
+				}
+			}
+			finally
 			{
-				doc.Save();
+				if (find != null) Marshal.ReleaseComObject(find);
+				if (selection != null) Marshal.ReleaseComObject(selection);
+				if (doc != null) Marshal.ReleaseComObject(doc);
+				if (opened != null) Marshal.ReleaseComObject(opened);
 			}
 		}
 
@@ -271,24 +323,35 @@ namespace River.OneMoreAddIn.Helpers.Office
 			var association = RegistryHelper.GetAssociation(ext);
 			if (association != null)
 			{
-				selection.Text = String.Empty;
+				MSWord.InlineShapes inlineShapes = null;
+				MSWord.InlineShape ole = null;
+				try
+				{
+					selection.Text = String.Empty;
 
-				object filename = target;
-				object linkToFile = !embedded;
-				object displayAsIcon = true;
-				object iconIndex = association.IconIndex;
-				object iconFilename = association.IconFilename;
-				object iconLabel = Path.GetFileName(target);
+					object filename = target;
+					object linkToFile = !embedded;
+					object displayAsIcon = true;
+					object iconIndex = association.IconIndex;
+					object iconFilename = association.IconFilename;
+					object iconLabel = Path.GetFileName(target);
 
-				selection.InlineShapes.AddOLEObject(
-					association.ProgID,
-					ref filename,
-					ref linkToFile,
-					ref displayAsIcon,
-					ref iconFilename,
-					ref iconIndex,
-					ref iconLabel
-					);
+					inlineShapes = selection.InlineShapes;
+					ole = inlineShapes.AddOLEObject(
+						association.ProgID,
+						ref filename,
+						ref linkToFile,
+						ref displayAsIcon,
+						ref iconFilename,
+						ref iconIndex,
+						ref iconLabel
+						);
+				}
+				finally
+				{
+					if (ole != null) Marshal.ReleaseComObject(ole);
+					if (inlineShapes != null) Marshal.ReleaseComObject(inlineShapes);
+				}
 
 				return;
 			}
@@ -298,9 +361,23 @@ namespace River.OneMoreAddIn.Helpers.Office
 
 			selection.Text = text;
 
-			object range = word.Selection.Range;
-			object uri = System.Web.HttpUtility.UrlDecode(new Uri(target).AbsoluteUri);
-			word.Selection.Hyperlinks.Add(range, ref uri);
+			MSWord.Range range = null;
+			MSWord.Hyperlinks hyperlinks = null;
+			MSWord.Hyperlink hyperlink = null;
+			try
+			{
+				range = selection.Range;
+				object anchor = range;
+				object uri = System.Web.HttpUtility.UrlDecode(new Uri(target).AbsoluteUri);
+				hyperlinks = selection.Hyperlinks;
+				hyperlink = hyperlinks.Add(anchor, ref uri);
+			}
+			finally
+			{
+				if (hyperlink != null) Marshal.ReleaseComObject(hyperlink);
+				if (hyperlinks != null) Marshal.ReleaseComObject(hyperlinks);
+				if (range != null) Marshal.ReleaseComObject(range);
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Enhancement or Defect Addressed by This PR

Applies findings from a memory-leak and defensive-hardening review of the OneMore add-in infrastructure (project root, `Helpers/`, `UI/`; `Commands/` was out of scope for the review). No user-visible feature change; this is mostly long-running session hygiene plus one latent PowerPoint-import crash fixed at the source.

## Description of Proposed Changes

### Memory leaks

- **`Helpers/Office/Outlook.cs`** — Fixed a double-release in `Dispose`. The "no user-launched Outlook" branch released `outlook` and set `disposed = true`, then fell through to an unconditional second `Marshal.ReleaseComObject(outlook)`. Now releases once, nulls the field, and honors `disposed` consistently.
- **`Helpers/Office/Word.cs`** — Captured intermediate COM RCWs and released them in `finally` blocks across `ConvertFileToHtml`, `ConvertClipboardToHtml`, `ResolveAttachmentRefs`, and `RenderAttachment`. The find/replace loop in `ResolveAttachmentRefs` now uses a single captured `Selection` instead of re-fetching `word.Selection.*` on every iteration. `word.Documents` is deliberately not captured/released (see PowerPoint note below) — `Application`-owned collections must be left to the `Application`.

### PowerPoint windowless-automation hazard

`ImportPowerPointFile` previously had `using var powerpoint = new PowerPoint();` at method scope, with multiple OneNote `await` calls between `ConvertFileToImages` and the using-disposal. PowerPoint opened with `WithWindow:msoFalse` (windowless automation) can detach its `Application` RCW across those awaits, so the final `power.Quit()` in `Dispose` threw `InvalidComObjectException` — even though the JPG export and OneNote import had already succeeded. This was latent in the original codebase, surfaced during this review.

- **`Commands/File/ImportCommand.cs`** — Scoped the `PowerPoint` instance to a block that ends before any `await`, matching the existing pattern in `ImportWordFile` (where the comment `// do not use single-line using here!!` flagged the same hazard for Word).
- **`Helpers/Office/PowerPoint.cs`** — Added a comment in `ConvertFileToImages` documenting why child COM objects (`Presentation`, `Slides`, `PageSetup`) are intentionally not released here: under windowless automation, releasing them detaches the `Application` itself and breaks subsequent `power.Quit()`.

### Defensive hardening

- **`Helpers/HttpClientFactory.cs`** — Added `SecurityProtocolType.Tls13` alongside `Tls12` so OneMore negotiates TLS 1.3 where the OS supports it.
- **`Helpers/ClipboardProvider.cs`** — `GetImage` switched to `Image.FromStream(stream, false, false)` to skip the validating GDI+ decode pass (historically the buggier path for malformed images planted on the clipboard by another process). Added a `<remarks>` block clarifying that the caller owns the returned Image's lifetime.
- **`AddIn.cs`** — `OnDisconnection` now unsubscribes `AppDomain.AssemblyResolve` / `UnhandledException` before the existing `Environment.Exit(0)` shutdown runs. Inert today (the process is about to exit), but safer if that hack is ever removed.

### Out of scope

`Commands/` was excluded from this review and is unchanged. A separate backlog of findings exists there (Updater MSI signature verification, telemetry payload sanitization, search-engine favicon SSRF, weak `Random` for IDs) and is not addressed in this PR.
