### PR TITLE
Index colorizer Styles by name for O(1) GetStyle lookup

### DIFF
--- a/OneMore/Colorizer/Theme.cs
+++ b/OneMore/Colorizer/Theme.cs
@@ -89,13 +89,38 @@ namespace River.OneMoreAddIn.Colorizer
 	/// </summary>
 	internal class Theme : ITheme
 	{
+		private Dictionary<string, Style> stylesByName;
+
 		public Dictionary<string, string> Colors { get; set; }
 
 		public List<Style> Styles { get; set; }
 
 		public Style GetStyle(string name)
 		{
-			return Styles.Find(s => s.Name == name);
+			if (name == null)
+			{
+				return null;
+			}
+
+			if (stylesByName == null)
+			{
+				stylesByName = new Dictionary<string, Style>(
+					Styles?.Count ?? 0,
+					System.StringComparer.OrdinalIgnoreCase);
+
+				if (Styles != null)
+				{
+					foreach (var style in Styles)
+					{
+						if (style.Name != null)
+						{
+							stylesByName[style.Name] = style;
+						}
+					}
+				}
+			}
+
+			return stylesByName.TryGetValue(name, out var s) ? s : null;
 		}
 
 
@@ -118,7 +143,8 @@ namespace River.OneMoreAddIn.Colorizer
 
 			foreach (var style in Styles)
 			{
-				// standardize on lowercase names because users are stupid
+				// standardize on lowercase names because users may be unpredictable in their
+				// use of case, and we want to be able to look up styles by name regardless
 				style.Name = style.Name.ToLower();
 
 				style.Background = TranslateColorName(style.Background);


### PR DESCRIPTION
## Summary

`Colorizer.Theme.GetStyle(name)` previously did `Styles.Find(s => s.Name == name)` — a linear scan over `List<Style>` on every call. The method is invoked per token during colorization, so the cost is O(tokens × styles) per page. Replace it with a lazy, case-insensitive `Dictionary<string, Style>` built on first lookup over the existing `List<Style>` backing store.

## Why this shape

- **Backing store unchanged.** `Styles` stays `List<Style>`, so the theme JSON wire format and every existing theme file keep working without migration.
- **Lazy build.** The index is constructed on the first `GetStyle` call, not in a constructor, so it doesn't depend on theme-loading order.
- **`StringComparer.OrdinalIgnoreCase`.** `TranslateColorNames` calls `GetStyle(\"PlainText\")` *before* the `foreach` that lowercases all style names. A case-insensitive comparer means the same index serves both pre- and post-lowercase lookups, so no invalidation step is needed and the `// standardize on lowercase names` loop becomes belt-and-suspenders rather than load-bearing.
- **Null-safe** on `Styles` and on `style.Name` — matches the defensive style elsewhere in the file.

## Caveats (intentionally not addressed)

1. **No invalidation on `Styles` setter.** Reassigning `Styles = newList` after `GetStyle` has been called would leave a stale index. `Theme` is treated as immutable after load in the current codebase, so this matches actual usage.
2. **Not thread-safe under concurrent first calls.** Two threads calling `GetStyle` simultaneously could each build a dictionary; the loser is just GC'd, no corruption. Colorization runs single-threaded per page, so this is fine for current usage.

Either caveat can be tightened later if the usage pattern changes.

## Context

Came out of a general code-quality review of the main OneMore project (excluding `Commands/`). This is the lowest-risk Tier-1 win from that review.

## Test plan

- [ ] Build OneMore locally (`build.ps1 -fast`).
- [ ] Open a OneNote page containing a colorized code block in at least one language and confirm the rendered output is byte-identical to `main` for the same input.
- [ ] Switch between a light theme and a dark theme on a colorized page and confirm `PlainText` foreground still gets the `AutoNative` override in dark mode (exercises the pre-lowercase `GetStyle(\"PlainText\")` path).
- [ ] Re-colorize the same page twice in a row and confirm no regressions (exercises the lazy build / second-call cached path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)