### PR TITLE
Fix typos and broken patterns in Colorizer language definitions

### DIFF
--- a/OneMore/Colorizer/Languages/cpp.json
+++ b/OneMore/Colorizer/Languages/cpp.json
@@ -50,7 +50,7 @@
       ]
     },
     {
-      "pattern": "\\b(alignas|alignof|and|and_eq|asm|auto|bitand|bitor|bool|break|case|catch|char|char8_t|char16_t|char32_t|class|compl|concept|c|const|const_cast|consteval|c|constexpr|constinit|continue|co_await|c|co_return|c|co_yield|c|decltype|default|delete|do|double|dynamic_cast|else|enum|explicit|export|extern|false|float|for|friend|goto|if|inline|int|long|mutable|namespace|new|noexcept|not|not_eq|nullptr|operator|or|or_eq|private|protected|public|register|reinterpret_cast|requires|c|return|short|signed|sizeof|static|static_assert|static_cast|struct|switch|template|this|thread_local|throwtrue|typedef|typeid|typename|union|unsigned|using|declaration|using|directive|virtual|void|volatile|wchar_t|while|xor|xor_eq)\\b",
+      "pattern": "\\b(alignas|alignof|and|and_eq|asm|auto|bitand|bitor|bool|break|case|catch|char|char8_t|char16_t|char32_t|class|compl|concept|const|const_cast|consteval|constexpr|constinit|continue|co_await|co_return|co_yield|decltype|default|delete|do|double|dynamic_cast|else|enum|explicit|export|extern|false|float|for|friend|goto|if|inline|int|long|mutable|namespace|new|noexcept|not|not_eq|nullptr|operator|or|or_eq|private|protected|public|register|reinterpret_cast|requires|return|short|signed|sizeof|static|static_assert|static_cast|struct|switch|template|this|thread_local|throw|true|typedef|typeid|typename|union|unsigned|using|virtual|void|volatile|wchar_t|while|xor|xor_eq)\\b",
       "captures": [
         "Keyword"
       ]

--- a/OneMore/Colorizer/Languages/golang.json
+++ b/OneMore/Colorizer/Languages/golang.json
@@ -43,7 +43,7 @@
       ]
     },
     {
-      "pattern": "\\b(break|case|chan|const|continue|default|defer|else|fallthrough|for|func|Go|Goto|if|interface|import|map|package|return|select|Struct|Switch|range|Type|Var)\\b",
+      "pattern": "\\b(break|case|chan|const|continue|default|defer|else|fallthrough|for|func|go|goto|if|interface|import|map|package|range|return|select|struct|switch|type|var)\\b",
       "captures": [
         "Keyword"
       ]

--- a/OneMore/Colorizer/Languages/php.json
+++ b/OneMore/Colorizer/Languages/php.json
@@ -43,13 +43,13 @@
       ]
     },
     {
-      "pattern": "\\b\\$([a-aA-Z0-9]{1,})\\b",
+      "pattern": "\\b\\$([a-zA-Z_][a-zA-Z0-9_]*)\\b",
       "captures": [
         "Variable"
       ]
     },
     {
-      "pattern": "\\b(__halt_compiler|abstract|and|as|break|callable|case|catch|class|clone|const|continue|declare|default|die|do|echo|else|elseif|em|ty|enddeclare|endfor|endforeach|endif|endswitch|endwhile|eval|exit|extends|final|finally|fn|for|foreach|function|global|goto|if|imple|ents|include|include_once|instanceof|insteadof|interface|isset|list|match|namespace|new|or|print|private|protected|public|require|req|ire_once|return|static|switch|throw|trait|try|unset|use|var|while|xor|yield)\\b",
+      "pattern": "\\b(__halt_compiler|abstract|and|as|break|callable|case|catch|class|clone|const|continue|declare|default|die|do|echo|else|elseif|empty|enddeclare|endfor|endforeach|endif|endswitch|endwhile|eval|exit|extends|final|finally|fn|for|foreach|function|global|goto|if|implements|include|include_once|instanceof|insteadof|interface|isset|list|match|namespace|new|or|print|private|protected|public|require|require_once|return|static|switch|throw|trait|try|unset|use|var|while|xor|yield)\\b",
       "captures": [
         "Keyword"
       ]

--- a/OneMore/Colorizer/Languages/rust.json
+++ b/OneMore/Colorizer/Languages/rust.json
@@ -33,7 +33,7 @@
     {
       "pattern": "('#[^\\n]*?(?<!\\\\)')",
       "captures": [
-        "Char"
+        "String"
       ]
     },
     {

--- a/OneMore/Colorizer/Languages/wolfram.json
+++ b/OneMore/Colorizer/Languages/wolfram.json
@@ -4,8 +4,21 @@
   ],
   "rules": [
     {
-      "pattern": "(\\(\\*[^\\)]\\*\\))",
+      "pattern": "(\\(\\*(?:[^*]|\\*+[^*)])*\\*+\\))",
+      "captures": [
+        "Comment"
+      ]
+    },
+    {
+      "pattern": "(\\(\\*[^\\r\\n]*)$",
       "scope": "Comment",
+      "captures": [
+        "Comment"
+      ]
+    },
+    {
+      "pattern": "^([^\\r\\n]*\\*\\))",
+      "scope": "",
       "captures": [
         "Comment"
       ]

--- a/OneMore/Colorizer/Languages/xml.json
+++ b/OneMore/Colorizer/Languages/xml.json
@@ -87,11 +87,11 @@
     {
       "pattern": "(?xi)(<\\/)(?:([a-z][a-z0-9-]*)(:))?([a-z][a-z0-9-_\\.]*)(>)",
       "captures": [
-        "XmlDelimeter",
+        "XmlDelimiter",
         "XmlName",
-        "XmlDelimeter",
+        "XmlDelimiter",
         "XmlName",
-        "XmlDelimeter"
+        "XmlDelimiter"
       ]
     },
     {
@@ -103,7 +103,7 @@
     {
       "pattern": "(?s)(<!\\[CDATA\\[)(.*?)(\\]\\]>)",
       "captures": [
-        "XmlDelimter",
+        "XmlDelimiter",
         "XmlCDataSection",
         "XmlDelimiter"
       ]


### PR DESCRIPTION
## Summary

PR 1 of the Colorizer audit (#2030). Pure data-only typo and pattern fixes — no code, theme, or csproj changes. Each fix was hand-verified against the affected file and against `Themes/light-theme.json`.

### Fixes

- **`golang.json`** — six keywords were capitalized (`Go`, `Goto`, `Struct`, `Switch`, `Type`, `Var`). Go is case-sensitive, so the uppercase forms never matched real source. Lowercased.
- **`cpp.json`** — removed six stray `|c|` fragments from the keyword alternation (`const|c|const_cast`, `consteval|c|constexpr`, `co_await|c|co_return`, `co_yield|c|decltype`, `requires|c|return`), which collapsed those positions to a literal `c`. Split run-together `throwtrue` → `throw|true`. Dropped `declaration` and `directive` from `using|declaration|using|directive` (those are descriptive terms, not C++ keywords).
- **`php.json`** — variable name character class was `[a-aA-Z0-9]` (`a-a` is just `a`); replaced with `[a-zA-Z_][a-zA-Z0-9_]*`. Three keyword typos restored: `em|ty` → `empty`, `imple|ents` → `implements`, `req|ire_once` → `require_once`.
- **`rust.json`** — Rust char-literal capture used scope `"Char"`, which is not defined in either theme. Changed to `"String"` so the tokens render styled. (Adding a dedicated `Char` theme entry is out of scope for this PR.)
- **`xml.json`** — fixed four occurrences of `"XmlDelimeter"`/`"XmlDelimter"` (typos of `XmlDelimiter`) on end-tag and CDATA-opener captures. These render unstyled today.
- **`wolfram.json`** — block-comment pattern was `(\(\*[^\)]\*\))`, which only matches a single non-`)` character between `(*` and `*)`. Replaced with `(\(\*(?:[^*]|\*+[^*)])*\*+\))` (allows any content including internal `*`), and added the matching multi-line start/end rules that other block-comment languages use.

### Why these aren't crashes today

`Colorizer.Colorize` (`OneMore/Colorizer/Colorizer.cs:165`, `:221`) falls back to plain text when `theme.GetStyle(scope)` returns null, so the typos degrade gracefully — affected tokens just render unstyled. The mangled keyword patterns simply fail to match, leaving the words as plain text. None of these defects throw.

Relates to #2030

## Test plan

- [x] Build OneMore (`build.ps1 -fast -local`). Confirm `Provider.LoadLanguageNames` (`Provider.cs:40`) logs no errors — a clean load means every regex compiles and capture counts validate.
- [x] In OneNote, colorize a Go snippet using `var x int`, `struct { … }`, `switch x { … }`, `type T = …` — confirm those words now render in the keyword colour.
- [x] Colorize a C++ snippet with `throw true;`, `using namespace std;`, `const int`, `co_await`, `co_return`, `co_yield` — keywords should colour correctly with no stray `c` matches.
- [x] Colorize a PHP snippet with `empty($x)`, `implements`, `require_once`, and a multi-letter variable like `$myVariable` — keyword and variable colours should apply.
- [x] Colorize a Rust snippet with a char literal `'a'` — should pick up the string colour.
- [x] Colorize an XML snippet with `</element>` and `<![CDATA[...]]>` — closing-tag brackets and CDATA delimiter should colour.
- [x] Colorize a Wolfram snippet with `(* short comment *)`, `(* comment with * internal *)`, and a multi-line `(* … \n … *)` — all should colour as Comment.