### PR TITLE
Modernize keyword lists in Colorizer language definitions

### DIFF
--- a/OneMore/Colorizer/Languages/cpp.json
+++ b/OneMore/Colorizer/Languages/cpp.json
@@ -50,7 +50,7 @@
       ]
     },
     {
-      "pattern": "\\b(alignas|alignof|and|and_eq|asm|auto|bitand|bitor|bool|break|case|catch|char|char8_t|char16_t|char32_t|class|compl|concept|const|const_cast|consteval|constexpr|constinit|continue|co_await|co_return|co_yield|decltype|default|delete|do|double|dynamic_cast|else|enum|explicit|export|extern|false|float|for|friend|goto|if|inline|int|long|mutable|namespace|new|noexcept|not|not_eq|nullptr|operator|or|or_eq|private|protected|public|register|reinterpret_cast|requires|return|short|signed|sizeof|static|static_assert|static_cast|struct|switch|template|this|thread_local|throw|true|typedef|typeid|typename|union|unsigned|using|virtual|void|volatile|wchar_t|while|xor|xor_eq)\\b",
+      "pattern": "\\b(alignas|alignof|and|and_eq|asm|auto|bitand|bitor|bool|break|case|catch|char|char8_t|char16_t|char32_t|class|compl|concept|const|const_cast|consteval|constexpr|constinit|continue|co_await|co_return|co_yield|decltype|default|delete|do|double|dynamic_cast|else|enum|explicit|export|extern|false|float|for|friend|goto|if|import|inline|int|long|module|mutable|namespace|new|noexcept|not|not_eq|nullptr|operator|or|or_eq|private|protected|public|register|reinterpret_cast|requires|return|short|signed|sizeof|static|static_assert|static_cast|struct|switch|template|this|thread_local|throw|true|typedef|typeid|typename|union|unsigned|using|virtual|void|volatile|wchar_t|while|xor|xor_eq)\\b",
       "captures": [
         "Keyword"
       ]

--- a/OneMore/Colorizer/Languages/csharp.json
+++ b/OneMore/Colorizer/Languages/csharp.json
@@ -71,7 +71,7 @@
       ]
     },
     {
-      "pattern": "\\b(abstract|as|ascending|base|bool|break|by|byte|case|catch|char|checked|class|const|continue|decimal|default|delegate|descending|do|double|dynamic|else|enum|equals|event|explicit|extern|false|finally|fixed|float|for|foreach|from|get|goto|group|if|implicit|in|int|into|interface|internal|is|join|let|lock|long|namespace|new|null|object|on|operator|orderby|out|override|params|partial|private|protected|public|readonly|ref|return|sbyte|sealed|select|set|short|sizeof|stackalloc|static|string|struct|switch|this|throw|true|try|typeof|uint|ulong|unchecked|unsafe|ushort|using|var|virtual|void|volatile|where|while|yield|async|await|warning|disable)\\b",
+      "pattern": "\\b(abstract|as|ascending|async|await|base|bool|break|by|byte|case|catch|char|checked|class|const|continue|decimal|default|delegate|descending|do|double|dynamic|else|enum|equals|event|explicit|extern|false|file|finally|fixed|float|for|foreach|from|get|goto|group|if|implicit|in|init|int|into|interface|internal|is|join|let|lock|long|managed|namespace|new|nint|notnull|nuint|null|object|on|operator|orderby|out|override|params|partial|private|protected|public|readonly|record|ref|required|return|sbyte|scoped|sealed|select|set|short|sizeof|stackalloc|static|string|struct|switch|this|throw|true|try|typeof|uint|ulong|unchecked|unmanaged|unsafe|ushort|using|var|virtual|void|volatile|where|while|with|yield)\\b",
       "captures": [
         "Keyword"
       ]

--- a/OneMore/Colorizer/Languages/golang.json
+++ b/OneMore/Colorizer/Languages/golang.json
@@ -49,7 +49,7 @@
       ]
     },
     {
-      "pattern": "\\b(byte|complex64|complex128|float32|float64|int|int8|int16|int32|int64|rune|uint|uintptr|uint8|uint16|uint32|uint64)\\b",
+      "pattern": "\\b(any|byte|comparable|complex64|complex128|float32|float64|int|int8|int16|int32|int64|rune|uint|uintptr|uint8|uint16|uint32|uint64)\\b",
       "captures": [
         "PsuedoKeyword"
       ]

--- a/OneMore/Colorizer/Languages/java.json
+++ b/OneMore/Colorizer/Languages/java.json
@@ -40,7 +40,7 @@
       ]
     },
     {
-      "pattern": "\\b(abstract|assert|boolean|break|byte|case|catch|char|class|const|continue|default|do|double|else|enum|extends|false|final|finally|float|for|goto|if|implements|import|instanceof|int|interface|long|native|new|null|package|private|protected|public|return|short|static|strictfp|super|switch|synchronized|this|throw|throws|transient|true|try|void|volatile|while)\\b",
+      "pattern": "\\b(abstract|assert|boolean|break|byte|case|catch|char|class|const|continue|default|do|double|else|enum|extends|false|final|finally|float|for|goto|if|implements|import|instanceof|int|interface|long|native|new|non-sealed|null|package|permits|private|protected|public|record|return|sealed|short|static|strictfp|super|switch|synchronized|this|throw|throws|transient|true|try|var|void|volatile|while|yield)\\b",
       "captures": [
         "Keyword"
       ]

--- a/OneMore/Colorizer/Languages/javascript.json
+++ b/OneMore/Colorizer/Languages/javascript.json
@@ -44,7 +44,7 @@
       ]
     },
     {
-      "pattern": "\\b(abstract|boolean|break|byte|case|catch|char|class|const|continue|debugger|default|delete|do|double|else|enum|export|extends|false|final|finally|float|for|function|goto|if|implements|import|in|instanceof|int|interface|long|native|new|null|package|private|protected|public|return|short|static|super|switch|synchronized|this|throw|throws|transient|true|try|typeof|var|void|volatile|while|with)\\b",
+      "pattern": "\\b(abstract|async|await|boolean|break|byte|case|catch|char|class|const|continue|debugger|default|delete|do|double|else|enum|export|extends|false|final|finally|float|for|function|goto|if|implements|import|in|instanceof|int|interface|let|long|native|new|null|of|package|private|protected|public|return|short|static|super|switch|synchronized|this|throw|throws|transient|true|try|typeof|var|void|volatile|while|with|yield)\\b",
       "captures": [
         "Keyword"
       ]

--- a/OneMore/Colorizer/Languages/php.json
+++ b/OneMore/Colorizer/Languages/php.json
@@ -49,7 +49,7 @@
       ]
     },
     {
-      "pattern": "\\b(__halt_compiler|abstract|and|as|break|callable|case|catch|class|clone|const|continue|declare|default|die|do|echo|else|elseif|empty|enddeclare|endfor|endforeach|endif|endswitch|endwhile|eval|exit|extends|final|finally|fn|for|foreach|function|global|goto|if|implements|include|include_once|instanceof|insteadof|interface|isset|list|match|namespace|new|or|print|private|protected|public|require|require_once|return|static|switch|throw|trait|try|unset|use|var|while|xor|yield)\\b",
+      "pattern": "\\b(__halt_compiler|abstract|and|as|break|callable|case|catch|class|clone|const|continue|declare|default|die|do|echo|else|elseif|empty|enddeclare|endfor|endforeach|endif|endswitch|endwhile|enum|eval|exit|extends|final|finally|fn|for|foreach|function|global|goto|if|implements|include|include_once|instanceof|insteadof|interface|isset|list|match|namespace|new|or|print|private|protected|public|readonly|require|require_once|return|static|switch|throw|trait|try|unset|use|var|while|xor|yield)\\b",
       "captures": [
         "Keyword"
       ]

--- a/OneMore/Colorizer/Languages/python.json
+++ b/OneMore/Colorizer/Languages/python.json
@@ -51,7 +51,7 @@
     },
     {
       // [8] (keyword)
-      "pattern": "\\b(and|as|assert|async|await|break|class|continue|def|del|elif|else|except|exec|False|finally|for|from|global|if|import|in|is|lambda|None|not|or|pass|print|raise|return|True|try|while|yield)\\b",
+      "pattern": "\\b(and|as|assert|async|await|break|case|class|continue|def|del|elif|else|except|exec|False|finally|for|from|global|if|import|in|is|lambda|match|None|nonlocal|not|or|pass|print|raise|return|True|try|while|with|yield)\\b",
       "captures": [
         "Keyword"
       ]

--- a/OneMore/Colorizer/Languages/rust.json
+++ b/OneMore/Colorizer/Languages/rust.json
@@ -49,7 +49,7 @@
       ]
     },
     {
-      "pattern": "\\b(as|break|const|continue|crate|else|enum|extern|false|fn|for|if|impl|in|let|loop|match|mod|move|mut|pub|ref|return|self|Self|static|struct|super|trait|true|type|unsafe|use|where|while)\\b",
+      "pattern": "\\b(as|async|await|break|const|continue|crate|dyn|else|enum|extern|false|fn|for|if|impl|in|let|loop|match|mod|move|mut|pub|ref|return|self|Self|static|struct|super|trait|true|type|union|unsafe|use|where|while)\\b",
       "captures": [
         "Keyword"
       ]

--- a/OneMore/Colorizer/Languages/typescript.json
+++ b/OneMore/Colorizer/Languages/typescript.json
@@ -43,7 +43,7 @@
       ]
     },
     {
-      "pattern": "\\b(abstract|any|async|await|bool|boolean|break|byte|case|catch|char|class|const|constructor|continue|debugger|declare|default|delete|do|double|else|enum|export|extends|false|final|finally|float|for|function|goto|if|implements|import|in|instanceof|int|interface|long|module|native|new|number|null|package|private|protected|public|return|short|static|string|super|switch|synchronized|this|throw|throws|transient|true|try|typeof|var|void|volatile|while|with)\\b",
+      "pattern": "\\b(abstract|any|as|asserts|async|await|bool|boolean|break|byte|case|catch|char|class|const|constructor|continue|debugger|declare|default|delete|do|double|else|enum|export|extends|false|final|finally|float|for|function|goto|if|implements|import|in|infer|instanceof|int|interface|is|keyof|let|long|module|namespace|native|never|new|number|null|of|out|package|private|protected|public|readonly|return|satisfies|short|static|string|super|switch|synchronized|this|throw|throws|transient|true|try|type|typeof|unknown|var|void|volatile|while|with|yield)\\b",
       "captures": [
         "Keyword"
       ]


### PR DESCRIPTION
## Summary

PR 2 of the Colorizer audit (#2030). Each of nine language keyword lists is brought up to current language versions. Data-only — no code, theme, or csproj changes.

### Additions per language

- **C++** — `import`, `module` (C++20 modules).
- **C#** — `record`, `init`, `with` (C# 9), `nint`, `nuint` (C# 9), `notnull`, `unmanaged` (constraints, C# 7.3+), `file`, `required`, `scoped` (C# 11), `managed` (function-pointer calling convention). Also removed the spurious `warning|disable` tail — these are `#pragma` parameters (already handled by the preprocessor rule), not C# keywords; leaving them in the keyword list would falsely colour any variable named `warning` or `disable`.
- **Java** — `var` (10), `yield` (14), `record` (16), `sealed`, `permits`, `non-sealed` (17). The hyphenated `non-sealed` works correctly inside `\b…\b` because `\b` only enforces boundaries at the start/end of the matched alternation.
- **Rust** — `async`, `await` (1.39), `dyn` (1.27), `union` (1.19).
- **Go** — `any`, `comparable` (Go 1.18). These are predeclared identifiers rather than reserved keywords, so they're added to the existing `PsuedoKeyword` group alongside `int`, `byte`, `rune`, etc.
- **Python** — `with` (a hard keyword since Python 2.6, surprisingly missing), `nonlocal` (3.0), and soft keywords `match`, `case` (3.10 structural pattern matching).
- **PHP** — `enum`, `readonly` (PHP 8.1).
- **TypeScript** — `type`, `keyof`, `infer`, `satisfies`, `readonly`, `is`, `asserts`, `out`, `unknown`, `never`, `namespace`, plus ES2015+ keywords `let`, `as`, `of`, `yield` (none of which were present).
- **JavaScript** — ES2015+ keywords `let`, `async`, `await`, `yield`, `of`.

### Out of scope

- Coverage-gap features (template literals, f-strings, decorators, CSS at-rules, etc.) — tracked separately as PR 3 in #2030.
- Built-in function highlighting (`make`, `len`, `append`, … in Go; `print`, `len`, `range` in Python) — would need a new style category and a separate decision.
- The TypeScript keyword list still contains several Java-isms (`byte`, `char`, `long`, `short`, `synchronized`, `throws`, `transient`, `native`, `final`, `float`, `double`, `int`) inherited from whatever template it started from. Not adding new bogus entries and not removing them in this PR — that's a cleanup for another day.

Relates to #2030

## Test plan

- [ ] Build OneMore (`build.ps1 -fast -local`). Confirm `Provider.LoadLanguageNames` logs no errors — every regex still compiles and capture counts validate.
- [ ] Colorize a C# 11 snippet with `file class Foo`, `record Person(string Name)`, `required string Bar`, `with { … }`, `init`, `scoped ref` — confirm new keywords colour.
- [ ] Colorize a Java 21 snippet with `record Point(int x, int y) {}`, `sealed interface Shape permits Circle, Square`, `non-sealed class Foo`, `var x = …`, switch `yield` — confirm new keywords colour.
- [ ] Colorize a Rust snippet with `async fn`, `.await`, `dyn Trait`, `union U` — confirm new keywords colour.
- [ ] Colorize a Go snippet with `func F[T any](x T) {}`, `func G[T comparable](x T) {}` — confirm `any` and `comparable` colour as types.
- [ ] Colorize a Python 3.10 snippet with `match x:`, `case 1:`, `with open(f) as fp:`, `nonlocal y` — confirm new keywords colour.
- [ ] Colorize a PHP 8.1 snippet with `enum Status { … }`, `readonly string $name` — confirm new keywords colour.
- [ ] Colorize a TS snippet with `type Foo = …`, `keyof T`, `T extends infer U ? U : never`, `x as const satisfies Foo`, `readonly Array<T>` — confirm new keywords colour.
- [ ] Spot-check existing snippets in each language to ensure no previously-working keyword regressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)