### PR TITLE
Recognize Python string prefixes and decorators in Colorizer

### DIFF
--- a/OneMore/Colorizer/Languages/python.json
+++ b/OneMore/Colorizer/Languages/python.json
@@ -35,6 +35,34 @@
       ]
     },
     {
+      // prefixed triple-quoted string (single-line): f"""...""", r"""...""", b"""...""", rb"""..."""
+      "pattern": "((?:[rRbBfFuU]{1,2})\"{3}[^\\r\\n]*?\"{3})",
+      "captures": [
+        "String"
+      ]
+    },
+    {
+      // prefixed triple-quoted string (single-line, single-quoted): f'''...''', r'''...''', etc.
+      "pattern": "((?:[rRbBfFuU]{1,2})'{3}[^\\r\\n]*?'{3})",
+      "captures": [
+        "String"
+      ]
+    },
+    {
+      // prefixed string (double-quoted): f"...", r"...", b"...", rb"...", fr"..."
+      "pattern": "((?:[rRbBfFuU]{1,2})\"[^\\r\\n\"]*?\")",
+      "captures": [
+        "String"
+      ]
+    },
+    {
+      // prefixed string (single-quoted): f'...', r'...', b'...', etc.
+      "pattern": "((?:[rRbBfFuU]{1,2})'[^\\r\\n']*?')",
+      "captures": [
+        "String"
+      ]
+    },
+    {
       // [6] ('string')
       "pattern": "('[^\\r\\n\\']*\\')",
       "captures": [
@@ -47,6 +75,14 @@
       //"pattern": "\"(?:([^{}\"]+)|(\\{[^{}\"]+\\})+)\"", ;string,number
       "captures": [
         "String"
+      ]
+    },
+    {
+      // decorator at line start: @decorator, @module.func, @obj.method
+      // line-anchored to avoid matching the @ matrix-multiplication operator (Python 3.5+)
+      "pattern": "^\\s*(@[a-zA-Z_][a-zA-Z0-9_\\.]*)",
+      "captures": [
+        "Macro"
       ]
     },
     {


### PR DESCRIPTION
## Summary

First of the deferred PR 3 coverage-gap items from the Colorizer audit (#2030). Adds Python string-prefix and decorator support per the scope agreed in #2034.

### What's added

**Prefixed strings (single-line)** — four new rules, each placed before the existing prefix-less string rules:

| Prefix combos | Quote style | Example |
|---|---|---|
| `r/R/b/B/f/F/u/U` and two-char raw combos (`rb`, `br`, `Rb`, `fr`, `Fr`, etc.) | `"""…"""` | `f"""template"""` |
| same | `'''…'''` | `r'''pattern'''` |
| same | `"…"` | `f"hello {x}"` |
| same | `'…'` | `b'bytes'` |

Single regex `[rRbBfFuU]{1,2}` covers all legal prefix combinations the Python lexer accepts. Each rule is scoped as `String`.

**Decorators** — one new rule anchored to line start:

```
^\s*(@[a-zA-Z_][a-zA-Z0-9_.]*)
```

Captures `@decorator`, `@module.func`, `@functools.lru_cache`. Scoped as `Macro` (same scope rust.json uses for `#[attr]`). Line-start anchoring avoids false positives from the `@` matrix-multiplication operator (Python 3.5+).

### Out of scope (deferred)

- f-string `{expr}` expression interpolation highlighting — would need multi-rule state machine
- Prefixed multi-line triple-quoted strings spanning multiple lines — extending the existing multi-line docstring start/end rules to handle prefixes is a larger change
- Hex / binary / octal numeric literals (`0x…`, `0o…`, `0b…`) — separate concern

### Why these are safe

Each new rule has 1 regex capture matching `captures: ["…"]` (1 entry), so `Compiler.ValidateRule` accepts all of them. No named groups. All new rules use scopes already defined in `Themes/light-theme.json` (`String`, `Macro`). Order-sensitivity at runtime is handled because the prefixed-string rules are placed *before* the prefix-less string rules — but in practice .NET's leftmost-match semantics make ordering safe either way.

Relates to #2034
Relates to #2030

## Test plan

- [ ] Build OneMore. `Provider.LoadLanguageNames` should log no errors.
- [ ] Colorize a snippet with `f"hello {name}"` — entire string colours.
- [ ] Colorize `r"\n[a-z]+"` — raw string colours, backslashes are part of the string token.
- [ ] Colorize `b"bytes"` — byte string colours.
- [ ] Colorize `rb"raw bytes"` and `fr"raw fmt"` — combined-prefix strings colour.
- [ ] Colorize `f"""multi-prefix"""` and `r'''raw'''` — prefixed triple-quoted strings colour.
- [ ] Colorize a class with `@property`, `@staticmethod`, `@functools.lru_cache(maxsize=128)` — `@name` part colours as Macro; arguments after `(` are plain (intentional).
- [ ] Colorize `result = matrix_a @ matrix_b` — the `@` matrix-multiplication operator is NOT styled as a decorator (line-start anchor prevents this).
- [ ] Spot-check existing Python snippets: prefix-less strings, comments, keywords, numbers should colour the same as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)