### PR TITLE
Recognize JS/TS template literals in Colorizer

### DIFF
--- a/OneMore/Colorizer/Languages/javascript.json
+++ b/OneMore/Colorizer/Languages/javascript.json
@@ -44,6 +44,12 @@
       ]
     },
     {
+      "pattern": "(`[^\\r\\n]*?(?<!\\\\)`)",
+      "captures": [
+        "String"
+      ]
+    },
+    {
       "pattern": "\\b(abstract|async|await|boolean|break|byte|case|catch|char|class|const|continue|debugger|default|delete|do|double|else|enum|export|extends|false|final|finally|float|for|function|goto|if|implements|import|in|instanceof|int|interface|let|long|native|new|null|of|package|private|protected|public|return|short|static|super|switch|synchronized|this|throw|throws|transient|true|try|typeof|var|void|volatile|while|with|yield)\\b",
       "captures": [
         "Keyword"

--- a/OneMore/Colorizer/Languages/typescript.json
+++ b/OneMore/Colorizer/Languages/typescript.json
@@ -43,6 +43,12 @@
       ]
     },
     {
+      "pattern": "(`[^\\r\\n]*?(?<!\\\\)`)",
+      "captures": [
+        "String"
+      ]
+    },
+    {
       "pattern": "\\b(abstract|any|as|asserts|async|await|bool|boolean|break|byte|case|catch|char|class|const|constructor|continue|debugger|declare|default|delete|do|double|else|enum|export|extends|false|final|finally|float|for|function|goto|if|implements|import|in|infer|instanceof|int|interface|is|keyof|let|long|module|namespace|native|never|new|number|null|of|out|package|private|protected|public|readonly|return|satisfies|short|static|string|super|switch|synchronized|this|throw|throws|transient|true|try|type|typeof|unknown|var|void|volatile|while|with|yield)\\b",
       "captures": [
         "Keyword"


### PR DESCRIPTION
## Summary

Second of the deferred PR 3 coverage-gap items from #2030. Adds backtick-delimited template-literal support to both `javascript.json` and `typescript.json` per the scope agreed in #2036.

### What's added

One new rule per file, placed after the existing `'…'` and `"…"` string rules:

```
"pattern": "(`[^\r\n]*?(?<!\\)`)",
"captures": ["String"]
```

- **Plain**: `` `text` `` colours as String.
- **Interpolated**: `` `Hello, ${name}!` `` — entire literal colours; `${expr}` is not separately highlighted (nested-rule expression highlighting is a much bigger lift).
- **Tagged**: `` styled.div`color: red;` `` — the backtick portion colours; the tag identifier is matched by other rules.
- **Escaped backticks**: `` `with \` escape` `` — the `(?<!\)` lookbehind prevents premature termination, same convention csharp.json uses for verbatim strings.

### Out of scope (intentionally)

- **Multi-line template literals** (`` `…\n…\n` ``). The `Parser.Parse` scope-override state machine (`Parser.cs:184`-`:195`) special-cases the `"comment"` scope name only — meaning a multi-line String state could be clobbered by a `/*` inside the literal, leaving subsequent content unstyled. Single-line is the safe useful subset; multi-line is a follow-up once the Parser is taught to protect `"string"` overrides too.
- **`${expr}` interpolation expression highlighting** — would require nested-rule support not present in the current Compiler.
- **JSDoc / TSDoc**, **decorators** (`@dec`), **regex literals** (`/pattern/flags`) — separate items from the audit's PR 3 bucket; each can be its own future issue.

### Why this is safe

- 1 regex capture matches `captures: ["String"]` (1 entry) — passes `Compiler.ValidateRule`.
- No named groups; lookbehind `(?<!\)` excluded from capture count by the validator.
- `String` is a defined scope in both `light-theme.json` and `dark-theme.json`.
- Placed after existing string rules so it can't accidentally consume regular `"…"` or `'…'` content (though .NET leftmost-match semantics make ordering moot here since the new rule requires a leading backtick).

Relates to #2036
Relates to #2030

## Test plan

- [ ] Build OneMore (`build.ps1 -fast -local`). `Provider.LoadLanguageNames` should log no errors.
- [ ] Colorize a JS/TS snippet with `` `hello` ``, `` `value: ${x}` ``, `` `with \` escape` `` — all colour as String.
- [ ] Colorize a tagged-template snippet `` html`<div>${content}</div>` `` — the literal portion colours; `html` (the tag) is plain or matched by other rules.
- [ ] Confirm a multi-line `` `\n…\n` `` is NOT colored as String beyond the first line (known limitation; lines after the opening backtick render as plain).
- [ ] Spot-check existing JS/TS snippets: regular `"…"` and `'…'` strings, comments, keywords, numbers should colour the same as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)