### PR TITLE
Recognize CSS at-rule keywords in Colorizer

### DIFF
--- a/OneMore/Colorizer/Languages/css.json
+++ b/OneMore/Colorizer/Languages/css.json
@@ -2,6 +2,12 @@
   "name": "CSS",
   "rules": [
     {
+      "pattern": "(@(?:charset|container|counter-style|document|font-face|font-feature-values|import|keyframes|layer|media|namespace|page|property|scope|starting-style|supports|viewport))\\b",
+      "captures": [
+        "Keyword"
+      ]
+    },
+    {
       "pattern": "([^\\r\\n,{}]+)(?:,(?=[^}]*{)|\\s*{)",
       "captures": [
         "CssSelector"


### PR DESCRIPTION
## Summary

PR 3 / item 3 from the Colorizer audit. Adds at-rule keyword recognition to `css.json`. Pure data-only — one new rule, no edits to existing rules.

### What's added

One new rule, placed before the existing selector rule:

```
"pattern": "(@(?:charset|container|counter-style|document|font-face|font-feature-values|import|keyframes|layer|media|namespace|page|property|scope|starting-style|supports|viewport))\b",
"captures": ["Keyword"]
```

Covers the full set of at-rules in CSS Conditional Rules Level 5 / CSS Cascade 6 / CSS Animations / CSS Fonts: `@media`, `@keyframes`, `@font-face`, `@import`, `@supports`, `@container`, `@layer`, `@charset`, `@namespace`, `@page`, `@property`, `@counter-style`, `@scope`, `@starting-style`, `@document`, `@viewport`, `@font-feature-values`.

The remainder of the at-rule preamble (e.g. ` (max-width: 600px) ` after `@media`) still falls through to the existing selector rule. Only the `@xxx` keyword portion is distinguished — that's the part users want highlighted; the parameters reading as CssSelector is acceptable.

### Why this is safe

- 1 regex capture matches `captures: ["Keyword"]` (1 entry). Inner `(?:…)` is non-capturing.
- No named groups.
- `Keyword` is a defined scope in both themes.
- Rule order matters: this new rule is placed *before* the broad selector rule `([^\r\n,{}]+)…` so that the `@xxx` keyword wins at the start of the line. After the at-rule keyword is consumed, the engine resumes at the next character and the selector rule matches the rest of the preamble.

### Out of scope (deferred under #2030)

Each of the following would require restructuring the existing greedy property/value rule (`\s*([^:\n]+)\s*:\s*([^;\n]+)\s*;?`), which captures everything between `:` and `;` in one shot. Listing for future reference:

- **`!important`** as Keyword
- **Hex colours** (`#fff`, `#ffffff`, `#ffffffff`) as Number
- **Units** (`px`, `em`, `rem`, `vh`, `vw`, `%`, `deg`, `s`, `ms`)
- **Pseudo-classes** (`:hover`, `:nth-child()`) distinguished from base selector
- **Pseudo-elements** (`::before`, `::after`)
- **`var(--name)`** with the variable name highlighted separately
- **Functions** (`calc()`, `clamp()`, `min()`, `max()`, `rgb()`, `linear-gradient()`)

Relates to #2030

## Test plan

- [ ] Build OneMore (`build.ps1 -fast -local`). `Provider.LoadLanguageNames` should log no errors.
- [ ] Colorize a CSS snippet with `@media (max-width: 600px) { … }` — `@media` colours as Keyword (Blue in light theme); the rest of the preamble keeps its existing CssSelector colour.
- [ ] Same for `@keyframes spin { from … to … }`, `@import url(…)`, `@font-face { … }`, `@supports (display: grid) { … }`, `@container (min-width: 400px) { … }`, `@layer base { … }`.
- [ ] Spot-check regular CSS without at-rules: selectors, property/value pairs, comments should colour the same as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)