### PR TITLE
Guard against empty builder in PageReader.ReadTextFrom

### DIFF
--- a/OneMore/Models/PageReader.cs
+++ b/OneMore/Models/PageReader.cs
@@ -577,8 +577,15 @@ namespace River.OneMoreAddIn.Models
 			// the entire line, plus the beginning of the next line. This is better than always
 			// adding a newline if the whole line is selected because it's the lesser of two evils
 			// when pasting into Excel, for example.
-			var match = true;
 			var newline = Environment.NewLine;
+
+			// selection covered only non-text content (images, ink, etc.) so nothing was appended
+			if (builder.Length < newline.Length)
+			{
+				return builder.ToString();
+			}
+
+			var match = true;
 			for (var i = 0; i < newline.Length; i++)
 			{
 				if (builder[builder.Length - (newline.Length - i)] != newline[i])


### PR DESCRIPTION
When a selection covers only non-text content (images, ink, drawings), BuildText appends nothing to the StringBuilder. The trailing-newline trim loop then indexes into an empty buffer and throws IndexOutOfRangeException. Add an early return for the empty/short-buffer case so CopyAsText, PreviewMarkdown, and ConvertMarkdown all handle non-text selections gracefully.

Relates to #2040


## IS YOUR COMMIT SIGNED?
Note that this repo requires all commits to be properly signed, [see here](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more info

## Enhancement or Defect Addressed by This PR
What...

## Description of Proposed Changes
How...
