### PR TITLE
fix Navigator memory leaks and GDI over-allocation in heading loader …

### DIFF
--- a/OneMore/Commands/Navigator/HistoryControl.cs
+++ b/OneMore/Commands/Navigator/HistoryControl.cs
@@ -19,6 +19,8 @@ namespace River.OneMoreAddIn.Commands
 	{
 		private readonly PictureBox picture;
 		private readonly MoreLinkLabel link;
+		private EventHandler backColorChangedHandler;
+		private ToolTip tip;
 
 
 		public HistoryControl(HierarchyInfo info)
@@ -59,7 +61,7 @@ namespace River.OneMoreAddIn.Commands
 			// history items should have a Visited value but pinned items would not
 			if (info.Visited > 0)
 			{
-				var tip = new ToolTip();
+				tip = new ToolTip();
 				var visited = DateTimeHelper.FromTicksSeconds(info.Visited).ToFriendlyString();
 				tip.SetToolTip(link, $"{info.Path}\n{visited}");
 			}
@@ -69,11 +71,12 @@ namespace River.OneMoreAddIn.Commands
 			Height = 24;
 			Margin = new Padding(0, 2, 0, 2);
 
-			BackColorChanged += new EventHandler((s, e) =>
+			backColorChangedHandler = (s, e) =>
 			{
 				picture.BackColor = ((Control)s).BackColor;
 				link.BackColor = ((Control)s).BackColor;
-			});
+			};
+			BackColorChanged += backColorChangedHandler;
 
 			Controls.Add(link);
 			Controls.Add(picture);
@@ -82,13 +85,13 @@ namespace River.OneMoreAddIn.Commands
 
 		protected override void Dispose(bool disposing)
 		{
-			picture?.Dispose();
-			link?.Dispose();
-			BackColorChanged -= new EventHandler((s, e) =>
+			if (disposing)
 			{
-				picture.BackColor = ((Control)s).BackColor;
-				link.BackColor = ((Control)s).BackColor;
-			});
+				tip?.Dispose();
+				picture?.Dispose();
+				link?.Dispose();
+				BackColorChanged -= backColorChangedHandler;
+			}
 
 			base.Dispose(disposing);
 		}

--- a/OneMore/Commands/Navigator/NavigationProvider.cs
+++ b/OneMore/Commands/Navigator/NavigationProvider.cs
@@ -28,6 +28,7 @@ namespace River.OneMoreAddIn.Commands
 		private readonly bool quickNotes;
 		private FileSystemWatcher watcher;
 		private EventHandler<HistoryLog> navigated;
+		private int watcherRefCount;
 		private DateTime lastWrite;
 		private bool disposedValue;
 
@@ -80,27 +81,35 @@ namespace River.OneMoreAddIn.Commands
 		{
 			add
 			{
-				var dir = Path.GetDirectoryName(path);
-				var nam = Path.GetFileNameWithoutExtension(path);
-				var ext = Path.GetExtension(path);
-				watcher = new FileSystemWatcher(dir, $"{nam}*{ext}")
+				if (watcherRefCount == 0)
 				{
-					NotifyFilter = NotifyFilters.LastWrite
-				};
-				watcher.Changed += NavigationHandler;
-				watcher.Error += Watcher_Error;
-				watcher.EnableRaisingEvents = true;
+					var dir = Path.GetDirectoryName(path);
+					var nam = Path.GetFileNameWithoutExtension(path);
+					var ext = Path.GetExtension(path);
+					watcher = new FileSystemWatcher(dir, $"{nam}*{ext}")
+					{
+						NotifyFilter = NotifyFilters.LastWrite
+					};
+					watcher.Changed += NavigationHandler;
+					watcher.Error += Watcher_Error;
+					watcher.EnableRaisingEvents = true;
+				}
+				watcherRefCount++;
 				navigated += value;
 			}
 
 			remove
 			{
 				navigated -= value;
-				watcher.EnableRaisingEvents = false;
-				watcher.Changed -= NavigationHandler;
-				watcher.Error -= Watcher_Error;
-				watcher.Dispose();
-				watcher = null;
+				watcherRefCount--;
+				if (watcherRefCount == 0 && watcher != null)
+				{
+					watcher.EnableRaisingEvents = false;
+					watcher.Changed -= NavigationHandler;
+					watcher.Error -= Watcher_Error;
+					watcher.Dispose();
+					watcher = null;
+				}
 			}
 		}
 

--- a/OneMore/Commands/Navigator/NavigatorWindow.cs
+++ b/OneMore/Commands/Navigator/NavigatorWindow.cs
@@ -469,6 +469,8 @@ namespace River.OneMoreAddIn.Commands
 			var margin = SystemInformation.VerticalScrollBarWidth * 2;
 			MoreLinkLabel currentLabel = null;
 
+			using var g = pageBox.CreateGraphics();
+
 			foreach (var heading in headings)
 			{
 				var wrapper = new XElement("T", new XCData(heading.Text));
@@ -489,7 +491,6 @@ namespace River.OneMoreAddIn.Commands
 					Width = pageBox.Width - leftmar - margin
 				};
 
-				using var g = link.CreateGraphics();
 				var size = g.MeasureString(text, headFont);
 				link.Height = (int)(size.Height + link.Padding.Top + link.Padding.Bottom);
 


### PR DESCRIPTION
…(#2051)

- HistoryControl: store BackColorChanged delegate in a field so Dispose can actually remove it (anonymous delegate != reference-equal)
- HistoryControl: store ToolTip in a field and dispose it; was leaking an OS handle for every history/pinned item with a Visited timestamp
- NavigationProvider: guard Navigated.add with a ref-count so adding multiple subscribers no longer overwrites and leaks the FileSystemWatcher
- NavigatorWindow: hoist CreateGraphics() above the headings foreach loop; was allocating a new GDI device context per heading on every page load


## IS YOUR COMMIT SIGNED?
Note that this repo requires all commits to be properly signed, [see here](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more info

## Enhancement or Defect Addressed by This PR
What...

## Description of Proposed Changes
How...
