### PR TITLE
Update winget-releaser action to current maintainer and ubuntu runner

### DIFF
--- a/.github/workflows/winget-releaser.yml
+++ b/.github/workflows/winget-releaser.yml
@@ -4,11 +4,13 @@ on:
     types: [released]
 jobs:
   publish:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: vedantmgoyal2009/winget-releaser@93fd8b606a1672ec3e5c6c3bb19426be68d1a8b0 #v2
+      - uses: vedantmgoyal9/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e # v2
         with:
           identifier: stevencohn.OneMore
-          installers-regex: '\.msi$' # Only .msi files
+          installers-regex: '\.msi$'
           token: ${{ secrets.WINGET_TOKEN }}
-    
+

--- a/OneMore.sln
+++ b/OneMore.sln
@@ -68,6 +68,8 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{5771E974-F302-4CB6-86B8-B57C74C07709}"
 	ProjectSection(SolutionItems) = preProject
 		.github\workflows\build.yml = .github\workflows\build.yml
+		.github\workflows\pr-issue-link.yml = .github\workflows\pr-issue-link.yml
+		.github\workflows\winget-releaser.yml = .github\workflows\winget-releaser.yml
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ISSUE_TEMPLATE", "ISSUE_TEMPLATE", "{147D185C-D069-495B-955A-74C81BDD20CF}"


### PR DESCRIPTION
Fixes #1019

## Summary
- Switch runner from `windows-latest` to `ubuntu-latest` (action is Node.js-based, no Windows dependency)
- Update action owner from `vedantmgoyal2009` to `vedantmgoyal9` (maintainer's current GitHub username)
- Pin to updated commit hash `4ffc7888` for the v2 tag on the new repo
- Add `permissions: contents: read` for least-privilege job scoping
- Remove redundant inline comment on `installers-regex`

## Test plan
- [ ] Verify the action resolves correctly at `vedantmgoyal9/winget-releaser@4ffc7888`
- [ ] Confirm `WINGET_TOKEN` secret is still valid with write access to the `microsoft/winget-pkgs` fork
- [ ] Trigger a test release and confirm the WinGet PR is created successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)