### PR TITLE
Hashtag scanner: yield to OneNote during foreground work

### DIFF
--- a/OneMore/Commands/Tagging/HashtagCommand.cs
+++ b/OneMore/Commands/Tagging/HashtagCommand.cs
@@ -22,6 +22,7 @@ namespace River.OneMoreAddIn.Commands
 
 		private static HashtagDialog dialog;
 		private static bool commandIsActive = false;
+		private static IDisposable pauseHandle;
 
 
 		public HashtagCommand()
@@ -66,6 +67,10 @@ namespace River.OneMoreAddIn.Commands
 
 				dialog = new HashtagDialog(moreID);
 				dialog.FormClosed += Dialog_FormClosed;
+
+				// signal the background scanner to use a longer inter-page delay while this
+				// dialog is open, so its DB reads and OneNote COM calls aren't starved
+				pauseHandle = HashtagServicePause.Hold();
 
 				dialog.RunModeless(async (sender, e) =>
 				{
@@ -134,6 +139,9 @@ namespace River.OneMoreAddIn.Commands
 
 		private void Dialog_FormClosed(object sender, FormClosedEventArgs e)
 		{
+			pauseHandle?.Dispose();
+			pauseHandle = null;
+
 			if (dialog != null)
 			{
 				dialog.FormClosed -= Dialog_FormClosed;

--- a/OneMore/Commands/Tagging/HashtagScanner.cs
+++ b/OneMore/Commands/Tagging/HashtagScanner.cs
@@ -11,6 +11,7 @@ namespace River.OneMoreAddIn.Commands
 	using System.Collections.Generic;
 	using System.Diagnostics;
 	using System.Linq;
+	using System.Threading;
 	using System.Threading.Tasks;
 	using System.Xml.Linq;
 
@@ -135,11 +136,16 @@ namespace River.OneMoreAddIn.Commands
 		}
 
 
+		// extended delay used when a foreground command holds a HashtagServicePause token
+		private const int PausedThrottle = 500;
+
+
 		/// <summary>
 		/// Scan all notebooks for all hashtags
 		/// </summary>
+		/// <param name="token">Optional token to cancel the scan between pages</param>
 		/// <returns></returns>
-		public async Task Scan()
+		public async Task Scan(CancellationToken token = default)
 		{
 			var clock = new Stopwatch();
 			clock.Start();
@@ -241,7 +247,7 @@ namespace River.OneMoreAddIn.Commands
 						{
 							int tp;
 
-							(dp, tp) = await Scan(one, sections, notebookID, $"/{name}", forceThru);
+							(dp, tp) = await Scan(one, sections, notebookID, $"/{name}", forceThru, token);
 
 							Stats.DirtyPages += dp;
 							Stats.TotalPages += tp;
@@ -266,7 +272,8 @@ namespace River.OneMoreAddIn.Commands
 
 
 		private async Task<(int, int)> Scan(
-			OneNote one, XElement parent, string notebookID, string path, bool forceThru)
+			OneNote one, XElement parent, string notebookID, string path, bool forceThru,
+			CancellationToken token = default)
 		{
 			//logger.Verbose($"scanning parent {path}, forceThru={forceThru}");
 
@@ -308,6 +315,11 @@ namespace River.OneMoreAddIn.Commands
 
 							foreach (var page in pages)
 							{
+								if (token.IsCancellationRequested)
+								{
+									break;
+								}
+
 								var pid = page.Attribute("ID").Value;
 								pids.Add(pid);
 
@@ -321,10 +333,19 @@ namespace River.OneMoreAddIn.Commands
 									}
 								}
 
-								// throttle the workload to give breathing room to OneNote UI
+								// throttle the workload to give breathing room to OneNote UI;
+								// use an extended delay when a foreground command is active
 								if (throttle > 0)
 								{
-									await Task.Delay(throttle);
+									var delay = HashtagServicePause.IsPaused ? PausedThrottle : throttle;
+									try
+									{
+										await Task.Delay(delay, token);
+									}
+									catch (OperationCanceledException)
+									{
+										break;
+									}
 								}
 							}
 
@@ -347,7 +368,7 @@ namespace River.OneMoreAddIn.Commands
 				foreach (var group in groups)
 				{
 					var (dp, tp) = await Scan(
-						one, group, notebookID, $"{path}/{group.Attribute("name").Value}", forceThru);
+						one, group, notebookID, $"{path}/{group.Attribute("name").Value}", forceThru, token);
 
 					dirtyPages += dp;
 					totalPages += tp;

--- a/OneMore/Commands/Tagging/HashtagService.cs
+++ b/OneMore/Commands/Tagging/HashtagService.cs
@@ -164,7 +164,7 @@ namespace River.OneMoreAddIn.Commands
 			}
 
 			CleanupToken();
-			logger.WriteLine("hashtag service has stopped; check for exceptions above");
+			logger.WriteLine("hashtag service has stopped");
 		}
 
 

--- a/OneMore/Commands/Tagging/HashtagService.cs
+++ b/OneMore/Commands/Tagging/HashtagService.cs
@@ -1,4 +1,4 @@
-﻿//************************************************************************************************
+//************************************************************************************************
 // Copyright © 2023 Steven M Cohn. All rights reserved.
 //************************************************************************************************
 
@@ -31,10 +31,13 @@ namespace River.OneMoreAddIn.Commands
 		protected HashtagScheduler scheduler;
 		protected int scanInterval;
 		protected ThreadPriority threadPriority;
+		protected CancellationTokenSource serviceToken;
 
 		private int scanCount;
 		private long scanTime;
 		protected int hour;
+
+		private int running; // re-entrancy guard, Interlocked access only
 
 
 		public delegate void HashtagScannedHandler(object sender, HashtagScannedEventArgs e);
@@ -88,6 +91,9 @@ namespace River.OneMoreAddIn.Commands
 
 			hour = DateTime.Now.Hour;
 
+			serviceToken = new CancellationTokenSource();
+			Application.ApplicationExit += OnApplicationExit;
+
 			// new thread to provide a bit of isolation
 			var thread = new Thread(async () =>
 			{
@@ -104,6 +110,13 @@ namespace River.OneMoreAddIn.Commands
 		}
 
 
+		private void OnApplicationExit(object sender, EventArgs e)
+		{
+			logger.WriteLine("cancelling HashtagService on ApplicationExit");
+			serviceToken?.Cancel();
+		}
+
+
 		// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 		// This base method is executed in the context of the OneMore add-in running in OneNote.
 		// Compare against the OneMoreTray override.
@@ -111,21 +124,25 @@ namespace River.OneMoreAddIn.Commands
 		protected virtual async Task StartupLoop()
 		{
 			logger.Debug("StartupLoop() WaitForReady()");
-			if (!await WaitForReady())
+			if (!await WaitForReady(serviceToken.Token))
 			{
+				CleanupToken();
 				return;
 			}
 
 			// execute forever or until there are five consecutive errors...
 
 			var errors = 0;
-			while (errors < 5)
+			while (errors < 5 && !serviceToken.IsCancellationRequested)
 			{
 				try
 				{
-					await Scan();
-
+					await Scan(serviceToken.Token);
 					errors = 0;
+				}
+				catch (OperationCanceledException)
+				{
+					break;
 				}
 				catch (Exception exc)
 				{
@@ -133,17 +150,33 @@ namespace River.OneMoreAddIn.Commands
 					errors++;
 				}
 
-				if (errors < 5)
+				if (errors < 5 && !serviceToken.IsCancellationRequested)
 				{
-					await Task.Delay(scanInterval);
+					try
+					{
+						await Task.Delay(scanInterval, serviceToken.Token);
+					}
+					catch (OperationCanceledException)
+					{
+						break;
+					}
 				}
 			}
 
+			CleanupToken();
 			logger.WriteLine("hashtag service has stopped; check for exceptions above");
 		}
 
 
-		private async Task<bool> WaitForReady()
+		private void CleanupToken()
+		{
+			Application.ApplicationExit -= OnApplicationExit;
+			serviceToken?.Dispose();
+			serviceToken = null;
+		}
+
+
+		private async Task<bool> WaitForReady(CancellationToken token)
 		{
 			if (scheduler.State != ScanningState.None &&
 				scheduler.State != ScanningState.Ready &&
@@ -151,17 +184,6 @@ namespace River.OneMoreAddIn.Commands
 			{
 				await scheduler.Activate();
 			}
-
-			using var source = new CancellationTokenSource();
-
-			EventHandler handler = (object sender, EventArgs e) =>
-			{
-				logger.WriteLine("cancelling HashtagService on ApplicationExit");
-				source.Cancel();
-			};
-
-			// must cancel Task.Delay upon exit or OneNote will hang until Delay completes
-			Application.ApplicationExit += handler;
 
 			try
 			{
@@ -179,65 +201,72 @@ namespace River.OneMoreAddIn.Commands
 						logger.WriteLine($"hashtag service waiting, {scheduler.State}");
 					}
 
-					await Task.Delay(delay, source.Token);
-					if (!source.IsCancellationRequested)
-					{
-						scheduler.Refresh();
-						count++;
+					await Task.Delay(delay, token);
+					scheduler.Refresh();
+					count++;
 
-						// resume normal 10s interval
-						delay = PollingDelay;
-					}
+					// resume normal 10s interval
+					delay = PollingDelay;
 				}
-				while (scheduler.State != ScanningState.Ready && !source.IsCancellationRequested);
+				while (scheduler.State != ScanningState.Ready && !token.IsCancellationRequested);
 			}
-			catch (TaskCanceledException)
+			catch (OperationCanceledException)
 			{
 				logger.Verbose("WaitForReady canceled");
 			}
-			finally
-			{
-				Application.ApplicationExit -= handler;
-			}
 
-			return !source.IsCancellationRequested;
+			return !token.IsCancellationRequested;
 		}
 
 
-		protected async Task Scan()
+		protected async Task Scan(CancellationToken token = default)
 		{
-			using var scanner = new HashtagScanner();
-
-			if (notebookFilters is not null && notebookFilters.Length > 0)
+			// guard against overlapping scans if the interval is shorter than a scan's duration
+			if (Interlocked.CompareExchange(ref running, 1, 0) != 0)
 			{
-				scanner.SetNotebookFilters(notebookFilters);
+				logger.WriteLine("hashtag service: skipping scan, previous scan still in progress");
+				return;
 			}
 
-			await scanner.Scan();
-
-			var s = scanner.Stats;
-			scanCount++;
-			scanTime += scanner.Stats.Time;
-
-			var avg = scanTime / scanCount;
-
-			OnHashtagScanned?.Invoke(this,
-				new HashtagScannedEventArgs(s.TotalPages, s.DirtyPages, s.Time, scanCount, avg));
-
-			if (hour != DateTime.Now.Hour)
+			try
 			{
-				logger.WriteLine($"hashtag service scanned {scanCount} times in the last hour, averaging {avg}ms");
-				hour = DateTime.Now.Hour;
-				scanCount = 0;
-				scanTime = 0;
+				using var scanner = new HashtagScanner();
+
+				if (notebookFilters is not null && notebookFilters.Length > 0)
+				{
+					scanner.SetNotebookFilters(notebookFilters);
+				}
+
+				await scanner.Scan(token);
+
+				var s = scanner.Stats;
+				scanCount++;
+				scanTime += scanner.Stats.Time;
+
+				var avg = scanTime / scanCount;
+
+				OnHashtagScanned?.Invoke(this,
+					new HashtagScannedEventArgs(s.TotalPages, s.DirtyPages, s.Time, scanCount, avg));
+
+				if (hour != DateTime.Now.Hour)
+				{
+					logger.WriteLine($"hashtag service scanned {scanCount} times in the last hour, averaging {avg}ms");
+					hour = DateTime.Now.Hour;
+					scanCount = 0;
+					scanTime = 0;
+				}
+				else if (s.DirtyPages > 0 || s.Time > 1000)
+				{
+					scanner.Report("hashtag SERVICE");
+				}
+				else if (logger.IsDebug)
+				{
+					scanner.Report("hashtag service");
+				}
 			}
-			else if (s.DirtyPages > 0 || s.Time > 1000)
+			finally
 			{
-				scanner.Report("hashtag SERVICE");
-			}
-			else if (logger.IsDebug)
-			{
-				scanner.Report("hashtag service");
+				Interlocked.Exchange(ref running, 0);
 			}
 		}
 	}

--- a/OneMore/Commands/Tagging/HashtagServicePause.cs
+++ b/OneMore/Commands/Tagging/HashtagServicePause.cs
@@ -1,0 +1,51 @@
+//************************************************************************************************
+// Copyright © 2025 Steven M Cohn. All rights reserved.
+//************************************************************************************************
+
+namespace River.OneMoreAddIn.Commands
+{
+	using System;
+	using System.Threading;
+
+
+	/// <summary>
+	/// Process-wide reference-counted pause signal for the HashtagService scanner.
+	/// Foreground commands that make heavy OneNote COM calls hold a pause token via Hold()
+	/// to signal the background scanner to extend its inter-page throttle delay.
+	/// </summary>
+	internal static class HashtagServicePause
+	{
+		private static volatile int count;
+
+
+		/// <summary>
+		/// Returns true when at least one caller is holding a pause token.
+		/// </summary>
+		public static bool IsPaused => count > 0;
+
+
+		/// <summary>
+		/// Signals the scanner to back off while the returned handle is alive.
+		/// The caller must dispose the handle when it no longer needs the pause.
+		/// </summary>
+		public static IDisposable Hold()
+		{
+			Interlocked.Increment(ref count);
+			return new PauseHandle();
+		}
+
+
+		private sealed class PauseHandle : IDisposable
+		{
+			private int disposed;
+
+			public void Dispose()
+			{
+				if (Interlocked.Exchange(ref disposed, 1) == 0)
+				{
+					Interlocked.Decrement(ref count);
+				}
+			}
+		}
+	}
+}

--- a/OneMore/OneMore.csproj
+++ b/OneMore/OneMore.csproj
@@ -400,6 +400,7 @@
     <Compile Include="Commands\Tagging\HashtagScannedEventArgs.cs" />
     <Compile Include="Commands\Tagging\HashtagScanner.cs" />
     <Compile Include="Commands\Tagging\HashtagService.cs" />
+    <Compile Include="Commands\Tagging\HashtagServicePause.cs" />
     <Compile Include="Commands\Tagging\ScanningState.cs" />
     <Compile Include="Commands\Tagging\ScheduleScanDialog.cs">
       <SubType>Form</SubType>

--- a/OneMoreTray/ScheduledHashtagService.cs
+++ b/OneMoreTray/ScheduledHashtagService.cs
@@ -73,17 +73,22 @@ namespace OneMoreTray
 			// we want this to complete exactly once and then exit but allow
 			// for up to five consecutive errors during execution...
 
+			var token = serviceToken?.Token ?? default;
 			var errors = 0;
 			var done = false;
 
-			while (errors < 5 && !done)
+			while (errors < 5 && !done && !token.IsCancellationRequested)
 			{
 				try
 				{
-					await Scan();
+					await Scan(token);
 
 					errors = 0;
 					done = true;
+				}
+				catch (OperationCanceledException)
+				{
+					break;
 				}
 				catch (Exception exc)
 				{
@@ -91,9 +96,16 @@ namespace OneMoreTray
 					errors++;
 				}
 
-				if (!done)
+				if (!done && !token.IsCancellationRequested)
 				{
-					await Task.Delay(scanInterval);
+					try
+					{
+						await Task.Delay(scanInterval, token);
+					}
+					catch (OperationCanceledException)
+					{
+						break;
+					}
 				}
 			}
 


### PR DESCRIPTION
## Summary

- Add `CancellationToken` plumbing from `Startup()` through `StartupLoop`, `Scan`, and the per-page loop so the scanner exits cleanly on `ApplicationExit` instead of waiting for the next `Task.Delay` to elapse (F1)
- Add `HashtagServicePause` static class: foreground commands hold a pause token that signals the scanner to use a 500 ms inter-page delay instead of the default 20 ms, reducing COM contention while the dialog is active (F6)
- Wire `HashtagCommand` to hold the pause while `HashtagDialog` is open (F6)
- Add re-entrancy guard (`Interlocked.CompareExchange`) in `HashtagService.Scan` so a slow scan that overlaps the next poll interval is skipped rather than stacked (F8)
- Update `ScheduledHashtagService` in `OneMoreTray` to propagate the cancellation token (F1)

## Background

The `HashtagService` runs a background STA thread that makes `GetPage`, `GetSection`, and `Update` COM calls into OneNote every two minutes. Those calls marshal across the COM apartment boundary, serializing against foreground commands (Search, hashtag browsing) that use the same channel. Users reported OneNote becoming sluggish or unresponsive while the scanner is active.

**Root cause (COM):** the 20 ms per-page throttle gaps *between* COM calls but does nothing during one. When `HashtagDialog` is open the user is actively driving DB reads and COM lookups — the scanner should back off.

**Root cause (shutdown):** `StartupLoop`'s `Task.Delay(scanInterval)` had no `CancellationToken`, so closing OneNote would hang for up to 2 minutes waiting for the timer.

## Test plan

- [x] Start OneMore, open `OneMore › Tags › Find hashtags` — scanner log should show 500 ms inter-page delays while the dialog is open, reverting to 20 ms after it closes
- [x] Close OneNote while the log shows `"hashtag service waiting"` or mid-scan — OneNote should exit immediately; log should record `"cancelling HashtagService on ApplicationExit"`
- [x] Force-rescan (`Tags › Scan for hashtags…`) and verify hashtag results are unchanged
- [x] Set scan interval to 1 minute on a large notebook and confirm no overlapping scan warnings appear in the log

Relates to #2054

🤖 Generated with [Claude Code](https://claude.com/claude-code)