### PR TITLE
Hashtag scanner: reduce per-page allocations and DB contention

### DIFF
--- a/OneMore/Commands/Tagging/HashtagPageScanner.cs
+++ b/OneMore/Commands/Tagging/HashtagPageScanner.cs
@@ -6,6 +6,7 @@ namespace River.OneMoreAddIn.Commands
 {
 	using Models;
 	using System;
+	using System.Collections.Generic;
 	using System.Linq;
 	using System.Text.RegularExpressions;
 	using System.Xml.Linq;
@@ -95,6 +96,7 @@ namespace River.OneMoreAddIn.Commands
 		public Hashtags Scan()
 		{
 			var tags = new Hashtags();
+			var seen = new HashSet<(string, string)>();
 
 			var paragraphs = page.Root
 				.Elements(ns + "Outline")
@@ -109,7 +111,7 @@ namespace River.OneMoreAddIn.Commands
 				{
 					var count = tags.Count;
 
-					ScanParagraph(paragraph, tags);
+					ScanParagraph(paragraph, tags, seen);
 
 					if (editor != null && tags.Count != count)
 					{
@@ -123,14 +125,14 @@ namespace River.OneMoreAddIn.Commands
 		}
 
 
-		private void ScanParagraph(XElement paragraph, Hashtags tags)
+		private void ScanParagraph(XElement paragraph, Hashtags tags, HashSet<(string, string)> seen)
 		{
 			// where all the magic happens...
 
-			var text = paragraph.Elements(ns + "T")?
+			// string.Join avoids the quadratic allocations of Aggregate($"{x} {y}")
+			var text = string.Join(" ", paragraph.Elements(ns + "T")
 				.DescendantNodes().OfType<XCData>()
-				.Select(c => c.Value.PlainText())
-				.Aggregate(string.Empty, (x, y) => $"{x} {y}");
+				.Select(c => c.Value.PlainText()));
 
 			if (!string.IsNullOrWhiteSpace(text))
 			{
@@ -147,19 +149,18 @@ namespace River.OneMoreAddIn.Commands
 							// hashPattern always has at least one capture group
 							var capture = match.Groups[1].Captures[0];
 							var name = capture.Value;
-							var lower = name.ToLower();
 
-							if (lower == SkipRegion)
+							if (string.Equals(name, SkipRegion, StringComparison.OrdinalIgnoreCase))
 							{
 								keepTags = false;
 							}
-							else if (lower == KeepRegion)
+							else if (string.Equals(name, KeepRegion, StringComparison.OrdinalIgnoreCase))
 							{
 								keepTags = true;
 							}
-							// this "else" ensures the #Skip and #Keep tags are not captured
-							else if (keepTags &&
-								!tags.Exists(t => t.Tag == name && t.ObjectID == objectID))
+							// this "else" ensures the #Skip and #Keep tags are not captured;
+							// seen.Add() is O(1) amortized vs O(n) List.Exists
+							else if (keepTags && seen.Add((name, objectID)))
 							{
 								var context = ExtractContext(text, capture.Index, capture.Length);
 
@@ -181,34 +182,26 @@ namespace River.OneMoreAddIn.Commands
 
 			var children = paragraph
 				.Elements(ns + "OEChildren")
-				.Elements(ns + "OE");
+				.Elements(ns + "OE")
+				.ToList();
 
-			if (children.Any())
+			foreach (var child in children)
 			{
-				foreach (var child in children)
-				{
-					ScanParagraph(child, tags);
-				}
+				ScanParagraph(child, tags, seen);
 			}
 
-			var tables = paragraph.Elements(ns + "Table");
-			if (tables.Any())
+			foreach (var table in paragraph.Elements(ns + "Table"))
 			{
-				foreach (var table in tables)
-				{
-					var toes = table
-						.Elements(ns + "Row")
-						.Elements(ns + "Cell")
-						.Elements(ns + "OEChildren")
-						.Elements(ns + "OE");
+				var toes = table
+					.Elements(ns + "Row")
+					.Elements(ns + "Cell")
+					.Elements(ns + "OEChildren")
+					.Elements(ns + "OE")
+					.ToList();
 
-					if (toes.Any())
-					{
-						foreach (var toe in toes)
-						{
-							ScanParagraph(toe, tags);
-						}
-					}
+				foreach (var toe in toes)
+				{
+					ScanParagraph(toe, tags, seen);
 				}
 			}
 		}

--- a/OneMore/Commands/Tagging/HashtagPageScannerFactory.cs
+++ b/OneMore/Commands/Tagging/HashtagPageScannerFactory.cs
@@ -29,7 +29,8 @@ namespace River.OneMoreAddIn.Commands
 			// matches ##digits or ##word or #word, but not #digits
 			hashPattern = new Regex(unfiltered
 				? @"(?:^|[\s\[\({,])(##\d[\w\-_]{0,}|#{1,2}[^\W\d][\w\-_]{0,})"
-				: @"(?:^|[\s\[\({,])(##\d[\w\-_]{0,}|(?!#(?:[A-Fa-f0-9]{6}|define|else|endif|endregion|error|include|if|ifdef|ifndef|line|pragma|region|undef)(?:\s|$|\)|\]|}|[^\w\d\-_]))#{1,2}[^\W\d][\w\-_]{0,})"
+				: @"(?:^|[\s\[\({,])(##\d[\w\-_]{0,}|(?!#(?:[A-Fa-f0-9]{6}|define|else|endif|endregion|error|include|if|ifdef|ifndef|line|pragma|region|undef)(?:\s|$|\)|\]|}|[^\w\d\-_]))#{1,2}[^\W\d][\w\-_]{0,})",
+				RegexOptions.Compiled | RegexOptions.CultureInvariant
 				);
 
 			this.styleTemplate = styleTemplate;

--- a/OneMore/Commands/Tagging/HashtagProvider.cs
+++ b/OneMore/Commands/Tagging/HashtagProvider.cs
@@ -516,6 +516,9 @@ namespace River.OneMoreAddIn.Commands
 		/// <param name="knownIDs"></param>
 		public void DeletePhantoms(List<string> knownIDs, string sectionID, string sectionPath)
 		{
+			// HashSet for O(1) membership vs O(n) List.Contains
+			var knownSet = new HashSet<string>(knownIDs, StringComparer.Ordinal);
+
 			using var cmd = con.CreateCommand();
 			cmd.CommandType = CommandType.Text;
 			cmd.CommandText = "SELECT moreID, pageID FROM hashtag_page WHERE sectionID = @sid";
@@ -542,7 +545,7 @@ namespace River.OneMoreAddIn.Commands
 				while (reader.Read())
 				{
 					var pageID = reader.GetString(1);
-					if (!knownIDs.Contains(pageID))
+					if (!knownSet.Contains(pageID))
 					{
 						tagcmd.Parameters["@pid"].Value = pageID;
 						tagcmd.ExecuteNonQuery();

--- a/OneMore/Commands/Tagging/HashtagScanner.cs
+++ b/OneMore/Commands/Tagging/HashtagScanner.cs
@@ -203,6 +203,7 @@ namespace River.OneMoreAddIn.Commands
 					var accepted = knownNotebooks.Count == 0;
 
 					var forceThru = true;
+					XElement prefetched = null; // set when we already fetched the notebook
 
 					if (accepted)
 					{
@@ -223,10 +224,16 @@ namespace River.OneMoreAddIn.Commands
 							else
 							{
 								// notebook size is within threshold?
-								// this may load the notebook twice, but small cost
-								var populated = await one.GetNotebook(notebookID, OneNote.Scope.Pages);
-								accepted = populated.Descendants(ns + "Page")
+								// Scope.Pages is a superset of section metadata so we can reuse
+								// this result below instead of fetching the notebook a second time
+								prefetched = await one.GetNotebook(notebookID, OneNote.Scope.Pages);
+								accepted = prefetched.Descendants(ns + "Page")
 									.Count(e => e.Attribute("isInRecycleBin") is null) < MaxPagesThreshold;
+
+								if (!accepted)
+								{
+									prefetched = null; // not scanning, don't hold the reference
+								}
 							}
 						}
 						else
@@ -242,7 +249,8 @@ namespace River.OneMoreAddIn.Commands
 
 						var dp = 0;
 
-						var sections = await one.GetNotebook(notebookID);
+						// reuse prefetched data when available to avoid a second COM call
+						var sections = prefetched ?? await one.GetNotebook(notebookID);
 						if (sections is not null)
 						{
 							int tp;

--- a/OneMore/Commands/Tagging/HashtagService.cs
+++ b/OneMore/Commands/Tagging/HashtagService.cs
@@ -239,6 +239,11 @@ namespace River.OneMoreAddIn.Commands
 
 				await scanner.Scan(token);
 
+				// release accumulated XElement trees and COM RCWs while the scanner is idle;
+				// doing this once per scan is safe and avoids gen-2 pressure during the next scan
+				GC.Collect(2, GCCollectionMode.Optimized);
+				GC.WaitForPendingFinalizers();
+
 				var s = scanner.Stats;
 				scanCount++;
 				scanTime += scanner.Stats.Time;

--- a/OneMore/Helpers/DatabaseProvider.cs
+++ b/OneMore/Helpers/DatabaseProvider.cs
@@ -56,6 +56,17 @@ namespace River.OneMoreAddIn
 			{
 				con = new SQLiteConnection($"Data source={path}");
 				con.Open();
+
+				// WAL mode lets readers proceed concurrently with the scanner's write
+				// transactions; NORMAL synchronous is the safe companion to WAL;
+				// busy_timeout lets a conflicting writer back off instead of failing immediately
+				using var pragma = con.CreateCommand();
+				pragma.CommandText =
+					"PRAGMA journal_mode=WAL;" +
+					"PRAGMA synchronous=NORMAL;" +
+					"PRAGMA busy_timeout=3000;" +
+					"PRAGMA temp_store=MEMORY;";
+				pragma.ExecuteNonQuery();
 			}
 		}
 


### PR DESCRIPTION
## Summary

- Enable SQLite WAL mode in `DatabaseProvider`: readers (hashtag search UI, formula provider) no longer block during the scanner's write transactions; `PRAGMA busy_timeout=3000` lets conflicting writers back off instead of failing immediately (F2)
- Rewrite `ScanParagraph` hot path: `string.Join` instead of `Aggregate` (eliminates quadratic string allocations), `OrdinalIgnoreCase` instead of `.ToLower()`, and `HashSet<(string,string)>` dedup instead of `O(n)` `List.Exists` (F3)
- Add `RegexOptions.Compiled | CultureInvariant` to the hashtag pattern in `HashtagPageScannerFactory` — the pattern is created once per scan and reused across thousands of `Matches()` calls (F4)
- Convert `knownIDs` membership test in `DeletePhantoms` to `HashSet<string>` to avoid O(n²) behaviour on large sections (F5)
- Call `GC.Collect(2, GCCollectionMode.Optimized)` once after each scan to drop accumulated `XElement` trees and COM `RCW`s before the two-minute idle delay (F7)
- Cache the `Scope.Pages` notebook fetch used for the size-threshold check and reuse it instead of fetching the notebook a second time when the notebook is accepted (F9)

## Background

A code review of the Hashtag service identified several sources of per-scan GC churn and SQLite lock contention:

- `ScanParagraph` called `PlainText()` (3 regex-replace allocations) per CDATA node, then used `.Aggregate($"{x} {y}")` for quadratic string concat — ~500+ small allocations per page on a busy notebook.
- Without WAL mode, any foreground read of `OneMore.db` during a scanner write transaction (hashtag dialog, table formulas) would block immediately with `SQLITE_BUSY=0`.
- The per-scan XElement trees from `GetPage`/`GetNotebook` had no explicit collection point, accumulating into gen-2 across the two-minute idle period.

## Test plan

- [x] Build and install VSIX; confirm hashtag scan produces identical results before and after (force a rescan via `Tags › Scan for hashtags…`)
- [x] While a scan is running, open `OneMore.db` with an external SQLite browser and run a read query — confirm it does not block (WAL mode)
- [x] Confirm `OneMore.db-wal` and `OneMore.db-shm` sidecar files are created alongside `OneMore.db`
- [x] Open a page with `#skiphashtags` / `#keephashtags` regions and verify region-scoping still works correctly after the `OrdinalIgnoreCase` change
- [x] Open a page with duplicate hashtags in the same paragraph and verify no duplicates appear in the hashtag search results

Relates to #2054

🤖 Generated with [Claude Code](https://claude.com/claude-code)