### PR TITLE
fix OneMoreTray immediate exit when catalog exists

### DIFF
--- a/OneMore/Commands/Tagging/HashtagProvider.cs
+++ b/OneMore/Commands/Tagging/HashtagProvider.cs
@@ -53,7 +53,7 @@ namespace River.OneMoreAddIn.Commands
 				return false;
 			}
 
-			var con = new SQLiteConnection($"Data source={path}");
+			using var con = new SQLiteConnection($"Data source={path}");
 			con.Open();
 
 			using var cmd = con.CreateCommand();

--- a/OneMoreTray/ScanningJob.cs
+++ b/OneMoreTray/ScanningJob.cs
@@ -34,9 +34,9 @@ namespace OneMoreTray
 
 			scheduler = new HashtagScheduler();
 
-			// for debugging, pass an argument!
+			// for debugging, pass an argument to bypass the schedule-existence check
 			var args = Environment.GetCommandLineArgs();
-			if (args.Length == 0 && !scheduler.ScheduleExists)
+			if (args.Length == 1 && !scheduler.ScheduleExists)
 			{
 				ToastMissingSchedule();
 				return;


### PR DESCRIPTION
Relates to #2054

Two bugs conspire to kill OneMoreTray immediately after launch:

1. args.Length == 0 is always false — GetCommandLineArgs() always includes [0]=exe path (minimum length 1). The guard that calls ToastMissingSchedule() when no schedule file is present never fired. Fixed to args.Length == 1.

2. CatalogExists() opened a SQLiteConnection but never disposed it. Every call when the DB file exists leaks an open handle. When DropCatalog() later ran VACUUM (which requires exclusive access), SQLite returned SQLITE_BUSY, DropCatalog() returned false, HashtagScanned(failure) fired, DoScanned called Application.Exit() — immediate termination with no apparent scan. Fixed with using var con = new SQLiteConnection(...).


## IS YOUR COMMIT SIGNED?
Note that this repo requires all commits to be properly signed, [see here](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more info

## Enhancement or Defect Addressed by This PR
What...

## Description of Proposed Changes
How...
