### PR TITLE
Search: replace virtual ListView with virtualized card view

### DIFF
--- a/OneMore/Commands/Search/CardHit.cs
+++ b/OneMore/Commands/Search/CardHit.cs
@@ -1,0 +1,13 @@
+//************************************************************************************************
+// Copyright © 2026 Steven M Cohn. All rights reserved.
+//************************************************************************************************
+
+namespace River.OneMoreAddIn.Commands
+{
+	internal sealed class CardHit
+	{
+		public string PlainText { get; set; }
+		public string PageId { get; set; }
+		public string ObjectId { get; set; }
+	}
+}

--- a/OneMore/Commands/Search/CardModel.cs
+++ b/OneMore/Commands/Search/CardModel.cs
@@ -1,0 +1,22 @@
+//************************************************************************************************
+// Copyright © 2026 Steven M Cohn. All rights reserved.
+//************************************************************************************************
+
+namespace River.OneMoreAddIn.Commands
+{
+	using System.Collections.Generic;
+	using System.Drawing;
+
+
+	internal sealed class CardModel
+	{
+		public string Title { get; set; }       // null for page-scope (anonymous) cards
+		public string PageId { get; set; }
+		public Color SectionColor { get; set; }
+		public List<CardHit> Hits { get; } = new List<CardHit>();
+
+		// layout cache — computed by SearchResultsCardView.EnsureLayout
+		internal int Y;
+		internal int Height;
+	}
+}

--- a/OneMore/Commands/Search/SearchDialogTextControl.Designer.cs
+++ b/OneMore/Commands/Search/SearchDialogTextControl.Designer.cs
@@ -35,8 +35,7 @@ namespace River.OneMoreAddIn.Commands
 			this.findLabel = new River.OneMoreAddIn.UI.MoreLabel();
 			this.findBox = new River.OneMoreAddIn.UI.MoreTextBox();
 			this.searchButton = new River.OneMoreAddIn.UI.MoreButton();
-			this.resultsView = new System.Windows.Forms.ListView();
-			this.hitColumn = new System.Windows.Forms.ColumnHeader();
+			this.resultsView = new River.OneMoreAddIn.Commands.SearchResultsCardView();
 			this.morePanel1 = new River.OneMoreAddIn.UI.MorePanel();
 			this.prevButton = new River.OneMoreAddIn.UI.MoreButton();
 			this.nextButton = new River.OneMoreAddIn.UI.MoreButton();
@@ -137,29 +136,13 @@ namespace River.OneMoreAddIn.Commands
 			//
 			// resultsView
 			//
-			this.resultsView.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
-            this.hitColumn});
 			this.resultsView.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.resultsView.FullRowSelect = true;
-			this.resultsView.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.None;
-			this.resultsView.HideSelection = false;
 			this.resultsView.Location = new System.Drawing.Point(15, 207);
-			this.resultsView.MultiSelect = false;
 			this.resultsView.Name = "resultsView";
-			this.resultsView.OwnerDraw = true;
-			this.resultsView.ShowGroups = false;
 			this.resultsView.Size = new System.Drawing.Size(782, 353);
 			this.resultsView.TabIndex = 0;
 			this.resultsView.TabStop = false;
-			this.resultsView.UseCompatibleStateImageBehavior = false;
-			this.resultsView.View = System.Windows.Forms.View.Details;
-			this.resultsView.VirtualMode = true;
 			this.resultsView.KeyDown += new System.Windows.Forms.KeyEventHandler(this.HandleNavKey);
-			this.resultsView.Resize += new System.EventHandler(this.ResizeResultsView);
-			//
-			// hitColumn
-			//
-			this.hitColumn.Text = "Hit";
 			//
 			// morePanel1
 			//
@@ -389,8 +372,7 @@ namespace River.OneMoreAddIn.Commands
 		private UI.MoreLabel findLabel;
 		private UI.MoreTextBox findBox;
 		private UI.MoreButton searchButton;
-		private System.Windows.Forms.ListView resultsView;
-		private System.Windows.Forms.ColumnHeader hitColumn;
+		private SearchResultsCardView resultsView;
 		private UI.MorePanel morePanel1;
 		private UI.MorePanel morePanel2;
 		private UI.MorePanel optionsPanel;

--- a/OneMore/Commands/Search/SearchDialogTextControl.cs
+++ b/OneMore/Commands/Search/SearchDialogTextControl.cs
@@ -2,6 +2,8 @@
 // Copyright © 2025 Steven M Cohn. All rights reserved.
 //************************************************************************************************
 
+#pragma warning disable S125 // ignore commented out code
+
 namespace River.OneMoreAddIn.Commands
 {
 	using River.OneMoreAddIn.Models;
@@ -25,19 +27,7 @@ namespace River.OneMoreAddIn.Commands
 		private sealed class SearchHit
 		{
 			public string PlainText { get; set; }
-			public string Hyperlink { get; set; }
-		}
-
-		// One entry per visible row in the results ListView.
-		// Groups are section headers; hits are navigable matches.
-		private sealed class ResultItem
-		{
-			public bool IsGroup { get; set; }
-			public string Text { get; set; }
-			public Color SectionColor { get; set; }     // group only: left swatch color
-			public Color SectionBackColor { get; set; }  // group only: row background tint
-			public string Hyperlink { get; set; }        // hit only
-			public ListViewItem ViewItem { get; set; }   // lazily cached for OnRetrieveVirtualItem
+			public string ObjectId { get; set; }
 		}
 
 
@@ -46,24 +36,10 @@ namespace River.OneMoreAddIn.Commands
 		private const int UpdatedAfter = 3;
 		private const int UpdatedBefore = 4;
 
-		private readonly ThemeManager manager = ThemeManager.Instance;
-
-		// Matches the original HighlightBackground / HighlightForeground from the Designer
-		private static readonly Color SelectionBack = Color.FromArgb(215, 193, 255);
-		private static readonly Color SelectionFore = SystemColors.HighlightText;
-
 		private readonly ILogger logger;
 		private readonly Regex cleaner;
 		private CancellationTokenSource source;
 		private bool grouping;
-
-		private readonly List<ResultItem> results = new();
-		private readonly Dictionary<Color, SolidBrush> groupBrushes = new();
-
-		private Font groupFont;
-		private Font hitFont;
-		private SolidBrush hitBackBrush;					// unselected hit row background
-		private readonly SolidBrush selectionBackBrush;		// selected hit row background
 
 
 		public SearchDialogTextControl()
@@ -97,34 +73,14 @@ namespace River.OneMoreAddIn.Commands
 
 			// pattern to remove SPAN|A elements and &#nn; escaped characters
 			//
-			//
 			// NOTE, instead of ignoring escape sequences, use WebUtility.HtmlDecode(input);
-			//
 			//
 			cleaner = new Regex(
 				@"(?:<\s*(?:span|a)[^>]*?>)|(?:</(?:span|a)>)|(?:&#\d+;)",
 				RegexOptions.Compiled);
 
-			groupFont = new Font("Segoe UI", 8.5f, FontStyle.Bold, GraphicsUnit.Point);
-			hitFont = new Font("Segoe UI", 8.5f, FontStyle.Regular, GraphicsUnit.Point);
-			selectionBackBrush = new SolidBrush(SelectionBack);
-
-			// Wire virtual-mode events now so they are ready before first show
-			resultsView.RetrieveVirtualItem += OnRetrieveVirtualItem;
-			resultsView.DrawItem += OnDrawItem;
-			resultsView.DrawSubItem += OnDrawSubItem;
-			resultsView.DrawColumnHeader += (s, e) => e.DrawDefault = true;
-			resultsView.MouseClick += OnResultsMouseClick;
-
-			Disposed += (_, _) =>
-			{
-				groupFont?.Dispose();
-				hitFont?.Dispose();
-				hitBackBrush?.Dispose();
-				selectionBackBrush?.Dispose();
-				foreach (var brush in groupBrushes.Values) brush.Dispose();
-				groupBrushes.Clear();
-			};
+			resultsView.CardActivated += OnCardActivated;
+			resultsView.HitActivated += OnHitActivated;
 		}
 
 
@@ -152,13 +108,6 @@ namespace River.OneMoreAddIn.Commands
 		protected override void OnLoad(EventArgs e)
 		{
 			base.OnLoad(e);
-
-			// BackColor comes from the theme; create the brush now that it is known
-			resultsView.BackColor = manager.GetColor("ListView");
-			hitBackBrush = new SolidBrush(resultsView.BackColor);
-
-			hitColumn.Width = resultsView.Width - SystemInformation.VerticalScrollBarWidth;
-
 			findBox.Focus();
 		}
 
@@ -203,15 +152,6 @@ namespace River.OneMoreAddIn.Commands
 			{
 				Search(sender, e);
 				e.Handled = true;
-			}
-		}
-
-
-		private void ResizeResultsView(object sender, EventArgs e)
-		{
-			if (sender is ListView view)
-			{
-				hitColumn.Width = view.Width - SystemInformation.VerticalScrollBarWidth;
 			}
 		}
 
@@ -339,7 +279,7 @@ namespace River.OneMoreAddIn.Commands
 			searchButton.NotifyDefault(true);
 
 			// only show nav buttons if there is at least one navigable hit
-			nextButton.Visible = prevButton.Visible = results.Any(r => !r.IsGroup);
+			nextButton.Visible = prevButton.Visible = resultsView.HasHits;
 		}
 
 
@@ -348,170 +288,50 @@ namespace River.OneMoreAddIn.Commands
 
 		private void ClearResults()
 		{
-			results.Clear();
-			resultsView.VirtualListSize = 0;
+			resultsView.Clear();
 		}
 
 
 		/// <summary>
-		/// Appends a section group header (when groupTitle is non-null) followed by
-		/// all hits for that page. Updating VirtualListSize once per page batch keeps
-		/// the number of repaints proportional to pages searched, not matches found.
+		/// Appends a card for the page (when pageId/groupTitle are non-null) with all its hits.
+		/// Appending one card per page keeps the number of repaints proportional to pages
+		/// searched, not individual matches. SearchResultsCardView.AppendCard primes the
+		/// paint queue via Update() using the same trick as the previous virtual ListView.
 		/// </summary>
-		private void AddPageResults(string groupTitle, string sectionColor, IList<SearchHit> hits)
+		private void AddPageResults(string pageId, string groupTitle, string sectionColor, IList<SearchHit> hits)
 		{
-			if (groupTitle is not null)
+			var swatch = groupTitle != null ? ColorHelper.FromHtml(sectionColor) : Color.Empty;
+
+			var card = new CardModel
 			{
-				var color = ColorHelper.FromHtml(sectionColor);
-				var bg = resultsView.BackColor;
-
-				// 15% section color blended with the list background for the row tint
-				var tinted = Color.FromArgb(
-					(color.R * 15 + bg.R * 85) / 100,
-					(color.G * 15 + bg.G * 85) / 100,
-					(color.B * 15 + bg.B * 85) / 100);
-
-				results.Add(new ResultItem
-				{
-					IsGroup = true,
-					Text = groupTitle,
-					SectionColor = color,
-					SectionBackColor = tinted
-				});
-			}
+				Title = groupTitle,
+				PageId = pageId,
+				SectionColor = swatch
+			};
 
 			foreach (var hit in hits)
 			{
-				results.Add(new ResultItem
+				card.Hits.Add(new CardHit
 				{
-					Text = hit.PlainText,
-					Hyperlink = hit.Hyperlink
+					PlainText = hit.PlainText,
+					PageId = pageId,
+					ObjectId = hit.ObjectId
 				});
 			}
 
-			resultsView.VirtualListSize = results.Count;
-
-			// WM_PAINT is the lowest-priority message; without this the search loop's
-			// own SynchronizationContext continuations starve the paint and rows do not
-			// appear until the loop ends. Update() dispatches any pending paint for the
-			// invalid region (only the new tail rows) without re-invalidating.
-			resultsView.Update();
+			resultsView.AppendCard(card);
 		}
 
 
-		// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-		// Virtual ListView rendering
-
-		private void OnRetrieveVirtualItem(object sender, RetrieveVirtualItemEventArgs e)
+		private async void OnCardActivated(object sender, NavigateCardEventArgs e)
 		{
-			if (e.ItemIndex >= results.Count) return;
-			var result = results[e.ItemIndex];
-
-			// The item text and font are used by the ListView for keyboard search and
-			// accessibility; actual painting happens in OnDrawItem / OnDrawSubItem.
-			// Cache the ListViewItem on the result so sustained scroll over thousands
-			// of rows does not allocate one per visible-row callback.
-			e.Item = result.ViewItem ??= new ListViewItem(result.Text)
-			{
-				Font = result.IsGroup ? groupFont : hitFont
-			};
+			await NavigateTo(e.PageId, string.Empty);
 		}
 
 
-		private void OnDrawItem(object sender, DrawListViewItemEventArgs e)
+		private async void OnHitActivated(object sender, NavigateHitEventArgs e)
 		{
-			if (e.ItemIndex >= results.Count) return;
-
-			var result = results[e.ItemIndex];
-			var selected = (e.State & ListViewItemStates.Selected) != 0;
-
-			if (result.IsGroup)
-			{
-				e.Graphics.FillRectangle(GetGroupBrush(result.SectionBackColor), e.Bounds);
-			}
-			else if (selected)
-			{
-				e.Graphics.FillRectangle(selectionBackBrush, e.Bounds);
-			}
-			else
-			{
-				e.Graphics.FillRectangle(hitBackBrush, e.Bounds);
-			}
-
-			if ((e.State & ListViewItemStates.Focused) != 0)
-			{
-				e.DrawFocusRectangle();
-			}
-		}
-
-
-		private void OnDrawSubItem(object sender, DrawListViewSubItemEventArgs e)
-		{
-			if (e.ItemIndex >= results.Count) return;
-
-			var result = results[e.ItemIndex];
-
-			// MultiSelect = false so there is at most one selected index
-			var selected = resultsView.SelectedIndices.Count > 0
-				&& resultsView.SelectedIndices[0] == e.ItemIndex;
-
-			const TextFormatFlags flags =
-				TextFormatFlags.VerticalCenter |
-				TextFormatFlags.EndEllipsis |
-				TextFormatFlags.NoPrefix |
-				TextFormatFlags.SingleLine;
-
-			const int swatchW = 8;
-
-			if (result.IsGroup)
-			{
-				// Colored swatch on the left edge indicating the section's accent color
-				const int pad = 4;
-				var swatch = new Rectangle(
-					e.Bounds.X + pad, e.Bounds.Y + pad,
-					swatchW, e.Bounds.Height - pad * 2);
-
-				e.Graphics.FillRectangle(GetGroupBrush(result.SectionColor), swatch);
-
-				var textRect = new Rectangle(
-					swatch.Right + pad * 2, e.Bounds.Y,
-					e.Bounds.Width - swatch.Right - pad * 2, e.Bounds.Height);
-
-				TextRenderer.DrawText(e.Graphics, result.Text, groupFont, textRect, ForeColor, flags);
-			}
-			else
-			{
-				var foreColor = selected ? SelectionFore : ForeColor;
-				var textRect = new Rectangle(
-					e.Bounds.X + swatchW + 4, e.Bounds.Y, e.Bounds.Width - swatchW - 4, e.Bounds.Height);
-
-				TextRenderer.DrawText(e.Graphics, result.Text, hitFont, textRect, foreColor, flags);
-			}
-		}
-
-
-		// Returns a cached SolidBrush for the given color, allocating one on first use.
-		// Lifetime is tied to the control; brushes are disposed in the Disposed handler.
-		private SolidBrush GetGroupBrush(Color color)
-		{
-			if (!groupBrushes.TryGetValue(color, out var brush))
-			{
-				brush = new SolidBrush(color);
-				groupBrushes[color] = brush;
-			}
-			return brush;
-		}
-
-
-		private async void OnResultsMouseClick(object sender, MouseEventArgs e)
-		{
-			var hit = resultsView.HitTest(e.X, e.Y);
-			if (hit.Item is null || hit.Item.Index >= results.Count) return;
-
-			var result = results[hit.Item.Index];
-			if (result.IsGroup) return;
-
-			await NavigateTo(result);
+			await NavigateTo(e.PageId, e.ObjectId);
 		}
 
 
@@ -530,15 +350,13 @@ namespace River.OneMoreAddIn.Commands
 				MoveTo(-1);
 				e.Handled = true;
 			}
-			else if (e.KeyCode == Keys.Enter && e.Modifiers == Keys.None
-				&& resultsView.SelectedIndices.Count > 0)
+			else if (e.KeyCode == Keys.Enter && e.Modifiers == Keys.None)
 			{
-				var index = resultsView.SelectedIndices[0];
-				if (index < results.Count && !results[index].IsGroup)
+				var target = resultsView.GetSelectedTarget();
+				if (target.HasValue)
 				{
-					NavigateTo(results[index]);
+					_ = NavigateTo(target.Value.pageId, target.Value.objectId);
 				}
-
 				e.Handled = true;
 			}
 		}
@@ -550,38 +368,21 @@ namespace River.OneMoreAddIn.Commands
 
 		private async void MoveTo(int delta)
 		{
-			if (results.Count == 0) return;
-
-			// Start from the current selection, or from the appropriate edge when nothing is selected
-			var current = resultsView.SelectedIndices.Count > 0
-				? resultsView.SelectedIndices[0]
-				: (delta > 0 ? -1 : results.Count);
-
-			// Walk in the requested direction, skipping group header rows
-			var i = current;
-			var found = false;
-			while (true)
-			{
-				i += delta;
-				if (i < 0 || i >= results.Count) break;
-				if (!results[i].IsGroup) { found = true; break; }
-			}
-
-			if (!found) return;
-
-			resultsView.SelectedIndices.Clear();
-			resultsView.SelectedIndices.Add(i);
-			resultsView.EnsureVisible(i);
+			resultsView.MoveSelection(delta);
 			resultsView.Focus();
 
-			await NavigateTo(results[i]);
+			var target = resultsView.GetSelectedTarget();
+			if (target.HasValue)
+			{
+				await NavigateTo(target.Value.pageId, target.Value.objectId);
+			}
 		}
 
 
-		private async Task NavigateTo(ResultItem result)
+		private async Task NavigateTo(string pageId, string objectId = "")
 		{
 			await using var one = new OneNote();
-			await one.NavigateTo(result.Hyperlink);
+			await one.NavigateTo(pageId, objectId);
 		}
 
 
@@ -706,7 +507,7 @@ namespace River.OneMoreAddIn.Commands
 					pageLabel.Text = pageName;
 				}
 
-				var hits = await SearchPageBody(one, page, finder);
+				var hits = await SearchPageBody(page, finder);
 
 				// skip adding results if cancelled mid-page
 				if (source.IsCancellationRequested) break;
@@ -714,6 +515,7 @@ namespace River.OneMoreAddIn.Commands
 				if (hits.Any())
 				{
 					AddPageResults(
+						pageId,
 						grouping ? $"{info.Path}/{pageName}" : null,
 						info.Color,
 						hits);
@@ -724,15 +526,15 @@ namespace River.OneMoreAddIn.Commands
 
 		private async Task SearchPage(OneNote one, Page page, Regex finder)
 		{
-			var hits = await SearchPageBody(one, page, finder);
+			var hits = await SearchPageBody(page, finder);
 			if (hits.Any())
 			{
-				AddPageResults(null, null, hits);
+				AddPageResults(page.PageId, null, null, hits);
 			}
 		}
 
 
-		private async Task<IList<SearchHit>> SearchPageBody(OneNote one, Page page, Regex finder)
+		private async Task<IList<SearchHit>> SearchPageBody(Page page, Regex finder)
 		{
 			var ns = page.Namespace;
 
@@ -755,7 +557,7 @@ namespace River.OneMoreAddIn.Commands
 			// OperationCanceledException through the async void Search() call chain.
 			var matched = await Task.Run(() =>
 			{
-				var results = new List<(string objectId, string text)>();
+				var hits = new List<(string objectId, string text)>();
 				foreach (var paragraph in paragraphs)
 				{
 					if (token.IsCancellationRequested) break;
@@ -763,23 +565,19 @@ namespace River.OneMoreAddIn.Commands
 					var text = GetRawText(paragraph, ns);
 					if (text.Length > 0 && finder.IsMatch(text))
 					{
-						results.Add((paragraph.Attribute("objectID").Value, text));
+						hits.Add((paragraph.Attribute("objectID").Value, text));
 					}
 				}
-				return results;
+				return hits;
 			});
 
-			// Back on the UI thread — resolve hyperlinks via COM.
-			var hits = new List<SearchHit>(matched.Count);
-			foreach (var (objectId, text) in matched)
+			// Hyperlinks are resolved lazily at navigation time (one.NavigateTo(pageId, objectId))
+			// so no COM round-trip is needed here per hit.
+			return matched.Select(m => new SearchHit
 			{
-				hits.Add(new SearchHit
-				{
-					PlainText = text,
-					Hyperlink = one.GetHyperlink(page.PageId, objectId)
-				});
-			}
-			return hits;
+				PlainText = m.text,
+				ObjectId  = m.objectId
+			}).ToList();
 		}
 
 

--- a/OneMore/Commands/Search/SearchResultsCardView.cs
+++ b/OneMore/Commands/Search/SearchResultsCardView.cs
@@ -1,0 +1,612 @@
+//************************************************************************************************
+// Copyright © 2026 Steven M Cohn. All rights reserved.
+//************************************************************************************************
+
+namespace River.OneMoreAddIn.Commands
+{
+	using River.OneMoreAddIn;
+	using River.OneMoreAddIn.UI;
+	using System;
+	using System.Collections.Generic;
+	using System.Drawing;
+	using System.Linq;
+	using System.Windows.Forms;
+
+
+	/// <summary>
+	/// Virtualized scrollable panel that owner-paints search result cards — one card per page.
+	/// Each card shows the section path / page title and its matching paragraph snippets.
+	/// Painting cost is proportional to the number of visible cards, not total card count,
+	/// so the control scales to thousands of results without allocating a child Control per card.
+	/// </summary>
+	internal class SearchResultsCardView : MoreUserControl
+	{
+		// visual constants
+		private const int CardMarginH = 8;   // horizontal gap between control edge and card
+		private const int SwatchWidth = 5;   // section-color stripe on the left edge of card
+		private const int CardPadX = 8;      // horizontal padding between swatch and text
+		private const int CardPadV = 5;      // vertical padding inside card (top and bottom)
+		private const int TitleRowH = 26;    // height of the page-title row
+		private const int HitRowH = 22;      // height of each snippet row
+		private const int HitIndent = 8;     // additional indent for snippet rows
+		private const int CardGap = 6;       // gap between consecutive cards
+		private const int TopPad = 6;        // gap above first card
+		private const int CornerRadius = 6;
+		private const int MaxHits = 10_000;
+
+		private readonly List<CardModel> cards = new();
+		private bool layoutDirty;
+		private int totalHits;
+		private bool hitCap;
+
+		// selection
+		private int selectedCard = -1;
+		private int selectedHit = -1;
+
+		// hover
+		private int hoverCard = -1;
+		private int hoverHit = -1;
+
+		// themed resources
+		private SolidBrush cardBackBrush;
+		private Pen borderPen;
+		private SolidBrush selectionBackBrush;
+		private Color titleFore;
+		private Color hitFore;
+		private Color selectionFore;
+		private Color hoverFore;
+		private Font titleFont;
+		private Font hitFont;
+
+
+		public SearchResultsCardView()
+		{
+			SetStyle(
+				ControlStyles.OptimizedDoubleBuffer |
+				ControlStyles.UserPaint |
+				ControlStyles.AllPaintingInWmPaint, true);
+
+			AutoScroll = true;
+		}
+
+
+		public event EventHandler<NavigateCardEventArgs> CardActivated;
+		public event EventHandler<NavigateHitEventArgs> HitActivated;
+
+
+		public bool HasHits => cards.Any(c => c.Hits.Count > 0);
+
+
+		// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+		// Theming
+
+		protected override void OnLoad(EventArgs e)
+		{
+			base.OnLoad(e);  // calls ThemeManager.InitializeTheme → OnThemeChange in dark mode
+			if (cardBackBrush == null) OnThemeChange();  // ensure light mode resources too
+		}
+
+
+		public override void OnThemeChange()
+		{
+			base.OnThemeChange();
+			DisposeThemed();
+
+			cardBackBrush    = new SolidBrush(manager.GetColor("Control"));
+			borderPen        = new Pen(manager.GetColor("ControlDark"));
+			selectionBackBrush = new SolidBrush(manager.GetColor("Highlight"));
+			titleFore        = manager.GetColor("ControlText");
+			hitFore          = manager.GetColor("HintText");
+			selectionFore    = manager.GetColor("HighlightText");
+			hoverFore        = manager.GetColor("HoverColor");
+			BackColor        = manager.GetColor("ListView");
+
+			titleFont?.Dispose();
+			hitFont?.Dispose();
+			titleFont = new Font("Segoe UI", 8.5f, FontStyle.Bold, GraphicsUnit.Point);
+			hitFont   = new Font("Segoe UI", 8.5f, FontStyle.Regular, GraphicsUnit.Point);
+
+			Invalidate();
+		}
+
+
+		private void DisposeThemed()
+		{
+			cardBackBrush?.Dispose();    cardBackBrush = null;
+			borderPen?.Dispose();        borderPen = null;
+			selectionBackBrush?.Dispose(); selectionBackBrush = null;
+		}
+
+
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing)
+			{
+				DisposeThemed();
+				titleFont?.Dispose();
+				hitFont?.Dispose();
+			}
+			base.Dispose(disposing);
+		}
+
+
+		// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+		// Data model
+
+		public void Clear()
+		{
+			cards.Clear();
+			totalHits = 0;
+			hitCap = false;
+			layoutDirty = true;
+			selectedCard = selectedHit = -1;
+			hoverCard = hoverHit = -1;
+			AutoScrollMinSize = Size.Empty;
+			Invalidate();
+		}
+
+
+		public void AppendCard(CardModel card)
+		{
+			if (hitCap) return;
+
+			cards.Add(card);
+			totalHits += card.Hits.Count;
+
+			if (totalHits >= MaxHits)
+			{
+				hitCap = true;
+				cards.Add(new CardModel
+				{
+					Title = $"Showing first {MaxHits:N0} hits — refine your search to see more.",
+					SectionColor = Color.Empty
+				});
+			}
+
+			layoutDirty = true;
+			EnsureLayout();
+
+			// Invalidate from the new card down so it appears immediately.
+			// This is the paint-priming trick that prevents the search loop's
+			// SynchronizationContext continuations from starving WM_PAINT.
+			var newCard = hitCap ? cards[cards.Count - 2] : cards[cards.Count - 1];
+			var screenY = newCard.Y + AutoScrollPosition.Y;
+			if (screenY < ClientSize.Height)
+			{
+				var h = ClientSize.Height - Math.Max(0, screenY);
+				Invalidate(new Rectangle(0, Math.Max(0, screenY), ClientSize.Width, h));
+			}
+			Update();
+		}
+
+
+		// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+		// Layout
+
+		private void EnsureLayout()
+		{
+			if (!layoutDirty) return;
+
+			int y = TopPad;
+			foreach (var card in cards)
+			{
+				card.Y = y;
+				card.Height = CardPadV
+					+ (card.Title != null ? TitleRowH : 0)
+					+ card.Hits.Count * HitRowH
+					+ CardPadV;
+
+				// minimum height so an empty/anonymous card is still visible
+				if (card.Height < CardPadV * 2 + HitRowH)
+					card.Height = CardPadV * 2 + HitRowH;
+
+				y += card.Height + CardGap;
+			}
+
+			AutoScrollMinSize = new Size(0, Math.Max(0, y - CardGap));
+			layoutDirty = false;
+		}
+
+
+		// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+		// Painting
+
+		protected override void OnPaint(PaintEventArgs e)
+		{
+			base.OnPaint(e);
+			if (cards.Count == 0) return;
+
+			EnsureLayout();
+
+			// TextRenderer.DrawText uses GDI and ignores Graphics.TranslateTransform, so we
+			// must compute screen coordinates directly rather than relying on the world transform.
+			var scrollY = -AutoScrollPosition.Y;  // pixels scrolled down (positive)
+			e.Graphics.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.AntiAlias;
+
+			// convert clip rect to virtual coordinates for the binary search
+			var clipTop    = e.ClipRectangle.Top    + scrollY;
+			var clipBottom = e.ClipRectangle.Bottom + scrollY;
+
+			var start = BinarySearchFirst(clipTop);
+			for (int i = start; i < cards.Count && cards[i].Y < clipBottom; i++)
+			{
+				DrawCard(e.Graphics, cards[i], i, scrollY);
+			}
+		}
+
+
+		private void DrawCard(Graphics g, CardModel card, int cardIndex, int scrollY)
+		{
+			var cx        = CardMarginH;
+			var cw        = ClientSize.Width - CardMarginH * 2;
+			var screenTop = card.Y - scrollY;  // virtual → screen coordinate
+			var cardRect  = new Rectangle(cx, screenTop, cw, card.Height);
+
+			// Card body
+			g.FillRoundedRectangle(cardBackBrush, cardRect, CornerRadius);
+
+			// Section-color swatch — inset from corners to stay within the rounded region
+			if (card.SectionColor != Color.Empty)
+			{
+				var swatchRect = new Rectangle(
+					cx + 2, screenTop + CornerRadius,
+					SwatchWidth, card.Height - CornerRadius * 2);
+
+				using var swatchBrush = new SolidBrush(card.SectionColor);
+				g.FillRectangle(swatchBrush, swatchRect);
+			}
+
+			const TextFormatFlags flags =
+				TextFormatFlags.VerticalCenter |
+				TextFormatFlags.EndEllipsis |
+				TextFormatFlags.NoPrefix |
+				TextFormatFlags.SingleLine;
+
+			int contentX = cx + SwatchWidth + CardPadX;
+			int contentW = cw - SwatchWidth - CardPadX * 2;
+			int y        = screenTop + CardPadV;
+
+			// Title row
+			if (card.Title != null)
+			{
+				var isHovered = hoverCard == cardIndex && hoverHit == -1;
+				var fore      = isHovered ? hoverFore : titleFore;
+				var titleRect = new Rectangle(contentX, y, contentW, TitleRowH);
+
+				TextRenderer.DrawText(g, card.Title, titleFont ?? Font, titleRect, fore, flags);
+				y += TitleRowH;
+			}
+
+			// Hit rows
+			for (int i = 0; i < card.Hits.Count; i++)
+			{
+				var isSelected = selectedCard == cardIndex && selectedHit == i;
+				var isHovered  = hoverCard == cardIndex && hoverHit == i;
+
+				if (isSelected)
+				{
+					var selRect = new Rectangle(cx + 1, y, cw - 2, HitRowH);
+					g.FillRectangle(selectionBackBrush, selRect);
+				}
+
+				var fore    = isSelected ? selectionFore : isHovered ? hoverFore : hitFore;
+				var hitRect = new Rectangle(contentX + HitIndent, y, contentW - HitIndent, HitRowH);
+
+				TextRenderer.DrawText(g, card.Hits[i].PlainText, hitFont ?? Font, hitRect, fore, flags);
+				y += HitRowH;
+			}
+
+			// Border drawn last so it sits on top of the swatch
+			g.DrawRoundedRectangle(borderPen, cardRect, CornerRadius);
+		}
+
+
+		protected override void OnResize(EventArgs e)
+		{
+			base.OnResize(e);
+			// Row heights are fixed, so layout doesn't change on resize — just repaint
+			Invalidate();
+		}
+
+
+		protected override void WndProc(ref Message m)
+		{
+			base.WndProc(ref m);
+
+			// ScrollableControl.ScrollWindow BitBlts existing bits and only invalidates the
+			// newly exposed strip. After base processes the scroll, force a full repaint so
+			// OnPaint redraws all visible cards from the updated AutoScrollPosition.
+			const int WM_VSCROLL    = 0x0115;
+			const int WM_MOUSEWHEEL = 0x020A;
+
+			if (m.Msg == WM_VSCROLL || m.Msg == WM_MOUSEWHEEL)
+			{
+				// Invalidate + Update (Refresh) forces a synchronous repaint immediately after
+				// ScrollWindow's BitBlt so stale pixels don't linger on screen.
+				Refresh();
+			}
+		}
+
+
+		// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+		// Hit testing
+
+		private struct HitInfo
+		{
+			public int CardIndex;
+			public int HitIndex;  // -1 = title
+		}
+
+
+		private HitInfo? HitTest(Point screenPt)
+		{
+			if (cards.Count == 0 || layoutDirty) return null;
+
+			var vy = screenPt.Y - AutoScrollPosition.Y;  // virtual Y
+
+			var idx = BinarySearchFirst(vy);
+			if (idx >= cards.Count) return null;
+
+			var card = cards[idx];
+			if (vy < card.Y || vy >= card.Y + card.Height) return null;
+
+			int y = card.Y + CardPadV;
+
+			if (card.Title != null)
+			{
+				if (vy < y + TitleRowH)
+					return new HitInfo { CardIndex = idx, HitIndex = -1 };
+
+				y += TitleRowH;
+			}
+
+			for (int i = 0; i < card.Hits.Count; i++)
+			{
+				if (vy < y + HitRowH)
+					return new HitInfo { CardIndex = idx, HitIndex = i };
+
+				y += HitRowH;
+			}
+
+			return null;
+		}
+
+
+		protected override void OnMouseClick(MouseEventArgs e)
+		{
+			base.OnMouseClick(e);
+			var hit = HitTest(e.Location);
+			if (hit == null) return;
+
+			var card = cards[hit.Value.CardIndex];
+
+			if (hit.Value.HitIndex == -1 && card.PageId != null)
+			{
+				CardActivated?.Invoke(this, new NavigateCardEventArgs(card.PageId));
+			}
+			else if (hit.Value.HitIndex >= 0)
+			{
+				SelectHit(hit.Value.CardIndex, hit.Value.HitIndex);
+				var h = card.Hits[hit.Value.HitIndex];
+				HitActivated?.Invoke(this, new NavigateHitEventArgs(h.PageId, h.ObjectId));
+			}
+		}
+
+
+		protected override void OnMouseMove(MouseEventArgs e)
+		{
+			base.OnMouseMove(e);
+			var hit = HitTest(e.Location);
+
+			int newCard = hit?.CardIndex ?? -1;
+			int newHit  = hit?.HitIndex  ?? -1;
+
+			Cursor = hit != null ? Cursors.Hand : Cursors.Default;
+
+			if (newCard != hoverCard || newHit != hoverHit)
+			{
+				InvalidateHitRegion(hoverCard, hoverHit);
+				hoverCard = newCard;
+				hoverHit  = newHit;
+				InvalidateHitRegion(hoverCard, hoverHit);
+			}
+		}
+
+
+		protected override void OnMouseLeave(EventArgs e)
+		{
+			base.OnMouseLeave(e);
+			Cursor = Cursors.Default;
+			if (hoverCard >= 0)
+			{
+				InvalidateHitRegion(hoverCard, hoverHit);
+				hoverCard = hoverHit = -1;
+			}
+		}
+
+
+		// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+		// Keyboard navigation
+
+		public void MoveSelection(int delta)
+		{
+			if (cards.Count == 0) return;
+
+			if (selectedCard < 0)
+			{
+				if (delta > 0) SelectFirst();
+				else SelectLast();
+				return;
+			}
+
+			int c = selectedCard;
+			int h = selectedHit;
+
+			while (delta > 0)
+			{
+				h++;
+				if (h >= cards[c].Hits.Count)
+				{
+					c++;
+					while (c < cards.Count && cards[c].Hits.Count == 0) c++;
+					if (c >= cards.Count) return;
+					h = 0;
+				}
+				delta--;
+			}
+
+			while (delta < 0)
+			{
+				h--;
+				if (h < 0)
+				{
+					c--;
+					while (c >= 0 && cards[c].Hits.Count == 0) c--;
+					if (c < 0) return;
+					h = cards[c].Hits.Count - 1;
+				}
+				delta++;
+			}
+
+			SelectHit(c, h);
+		}
+
+
+		private void SelectFirst()
+		{
+			for (int c = 0; c < cards.Count; c++)
+			{
+				if (cards[c].Hits.Count > 0) { SelectHit(c, 0); return; }
+			}
+		}
+
+
+		private void SelectLast()
+		{
+			for (int c = cards.Count - 1; c >= 0; c--)
+			{
+				if (cards[c].Hits.Count > 0) { SelectHit(c, cards[c].Hits.Count - 1); return; }
+			}
+		}
+
+
+		private void SelectHit(int cardIndex, int hitIndex)
+		{
+			if (cardIndex == selectedCard && hitIndex == selectedHit) return;
+
+			InvalidateHitRegion(selectedCard, selectedHit);
+			selectedCard = cardIndex;
+			selectedHit  = hitIndex;
+			InvalidateHitRegion(selectedCard, selectedHit);
+
+			EnsureHitVisible(selectedCard, selectedHit);
+		}
+
+
+		public (string pageId, string objectId)? GetSelectedTarget()
+		{
+			if (selectedCard < 0 || selectedHit < 0) return null;
+			var h = cards[selectedCard].Hits[selectedHit];
+			return (h.PageId, h.ObjectId);
+		}
+
+
+		private void EnsureHitVisible(int cardIndex, int hitIndex)
+		{
+			if (cardIndex < 0 || hitIndex < 0) return;
+			EnsureLayout();
+
+			var card   = cards[cardIndex];
+			var hitTop = card.Y + CardPadV
+				+ (card.Title != null ? TitleRowH : 0)
+				+ hitIndex * HitRowH;
+			var hitBottom = hitTop + HitRowH;
+
+			var scrollY = -AutoScrollPosition.Y;
+			var clientH = ClientSize.Height;
+
+			if (hitTop < scrollY)
+				AutoScrollPosition = new Point(0, hitTop);
+			else if (hitBottom > scrollY + clientH)
+				AutoScrollPosition = new Point(0, hitBottom - clientH);
+		}
+
+
+		// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+		// Helpers
+
+		/// <summary>
+		/// Binary search for the first card whose bottom edge is below virtualY.
+		/// Returns cards.Count if all cards are above virtualY.
+		/// </summary>
+		private int BinarySearchFirst(int virtualY)
+		{
+			if (cards.Count == 0) return 0;
+
+			int lo = 0, hi = cards.Count - 1, result = cards.Count;
+
+			while (lo <= hi)
+			{
+				int mid = (lo + hi) / 2;
+				if (cards[mid].Y + cards[mid].Height > virtualY)
+				{
+					result = mid;
+					hi = mid - 1;
+				}
+				else
+				{
+					lo = mid + 1;
+				}
+			}
+
+			return result;
+		}
+
+
+		private void InvalidateHitRegion(int cardIndex, int hitIndex)
+		{
+			if (cardIndex < 0 || cardIndex >= cards.Count) return;
+			EnsureLayout();
+
+			var card = cards[cardIndex];
+			Rectangle rect;
+
+			if (hitIndex == -1)
+			{
+				var screenY = card.Y + CardPadV + AutoScrollPosition.Y;
+				rect = new Rectangle(0, screenY, ClientSize.Width, TitleRowH);
+			}
+			else if (hitIndex >= 0 && hitIndex < card.Hits.Count)
+			{
+				var hitTop  = card.Y + CardPadV
+					+ (card.Title != null ? TitleRowH : 0)
+					+ hitIndex * HitRowH;
+				var screenY = hitTop + AutoScrollPosition.Y;
+				rect = new Rectangle(0, screenY, ClientSize.Width, HitRowH);
+			}
+			else return;
+
+			if (rect.Bottom > 0 && rect.Top < ClientSize.Height)
+				Invalidate(rect);
+		}
+	}
+
+
+	internal sealed class NavigateCardEventArgs : EventArgs
+	{
+		public NavigateCardEventArgs(string pageId) { PageId = pageId; }
+		public string PageId { get; }
+	}
+
+
+	internal sealed class NavigateHitEventArgs : EventArgs
+	{
+		public NavigateHitEventArgs(string pageId, string objectId)
+		{
+			PageId   = pageId;
+			ObjectId = objectId;
+		}
+		public string PageId   { get; }
+		public string ObjectId { get; }
+	}
+}

--- a/OneMore/OneMore.csproj
+++ b/OneMore/OneMore.csproj
@@ -261,6 +261,8 @@
     <Compile Include="Commands\References\CheckUrlsCommand.cs" />
     <Compile Include="Commands\References\HyperlinkProvider.cs" />
     <Compile Include="Commands\Reminders\CleanRemindersCommand.cs" />
+    <Compile Include="Commands\Search\CardHit.cs" />
+    <Compile Include="Commands\Search\CardModel.cs" />
     <Compile Include="Commands\Search\SearchDialogActionControl.cs">
       <SubType>UserControl</SubType>
     </Compile>
@@ -275,6 +277,9 @@
       <DependentUpon>SearchDialogTextControl.cs</DependentUpon>
     </Compile>
     <Compile Include="Commands\Search\SearchGroupControl.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="Commands\Search\SearchResultsCardView.cs">
       <SubType>UserControl</SubType>
     </Compile>
     <Compile Include="Commands\Tools\ShowContainersCommand.cs" />


### PR DESCRIPTION
## Summary

- Replaces the owner-draw virtual `ListView` in `SearchDialogTextControl` with `SearchResultsCardView`, a custom virtualized owner-paint panel that renders rounded-corner cards (one per page), matching the visual style of `HashtagDialog`
- Painting cost scales with visible cards (~5–15), not total card count — handles thousands of results without allocating a child `Control` per card
- Drops the per-hit `GetHyperlink` COM round-trip by deferring navigation to `one.NavigateTo(pageId, objectId)` at click time (same pattern as `HashtagContextControl`)
- Hard cap at 10,000 hits with a visible "refine your search" notice card
- Full `ThemeManager` integration via `MoreUserControl` inheritance — light/dark theme-aware with no custom section-color tints

## Test plan

- [ ] Build solution with `.\build.ps1 -fast -main`
- [ ] Enable experimental setting (`GeneralSheet → experimental`) and open the Search dialog text tab
- [ ] Small result search (~10 hits, 3–5 pages): verify rounded cards with margins, section-color swatch, clickable title and hits, correct navigation
- [ ] Large result search (hundreds of hits): verify panel stays responsive while results stream in; cancel mid-search stops promptly
- [ ] Scroll through results: verify cards beyond first viewport render correctly (the `TranslateTransform` / `TextRenderer` bug fix)
- [ ] Keyboard nav: `N`/`Down`, `P`/`Up`, `Enter`, Next/Prev buttons all work; panel auto-scrolls to keep selection visible
- [ ] Resize dialog: cards repaint to new width
- [ ] Toggle light/dark theme: cards re-render with themed colors

Relates to #2059

🤖 Generated with [Claude Code](https://claude.com/claude-code)