### PR TITLE
Search: match card view colors to HashtagDialog, fix selection UX

### DIFF
--- a/OneMore/Commands/Search/SearchDialogTextControl.Designer.cs
+++ b/OneMore/Commands/Search/SearchDialogTextControl.Designer.cs
@@ -186,7 +186,7 @@ namespace River.OneMoreAddIn.Commands
 			// resultsView
 			// 
 			this.resultsView.AutoScroll = true;
-			this.resultsView.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(255)))), ((int)(((byte)(255)))), ((int)(((byte)(255)))));
+			this.resultsView.BackColor = System.Drawing.SystemColors.AppWorkspace;
 			this.resultsView.Dock = System.Windows.Forms.DockStyle.Fill;
 			this.resultsView.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
 			this.resultsView.Location = new System.Drawing.Point(15, 237);

--- a/OneMore/Commands/Search/SearchResultsCardView.cs
+++ b/OneMore/Commands/Search/SearchResultsCardView.cs
@@ -125,14 +125,14 @@ namespace River.OneMoreAddIn.Commands
 			base.OnThemeChange();
 			DisposeThemed();
 
-			cardBackBrush    = new SolidBrush(manager.GetColor("Control"));
+			cardBackBrush    = new SolidBrush(manager.GetColor("ControlLightLight"));
 			borderPen        = new Pen(manager.GetColor("ControlDark"));
 			selectionBackBrush = new SolidBrush(manager.GetColor("Highlight"));
 			titleFore        = manager.GetColor("ControlText");
 			hitFore          = manager.GetColor("HintText");
 			selectionFore    = manager.GetColor("HighlightText");
 			hoverFore        = manager.GetColor("HoverColor");
-			BackColor        = manager.GetColor("ListView");
+			BackColor        = manager.GetColor("AppWorkspace");
 
 			titleFont?.Dispose();
 			hitFont?.Dispose();
@@ -336,7 +336,7 @@ namespace River.OneMoreAddIn.Commands
 
 				if (isSelected)
 				{
-					var selRect = new Rectangle(cx + 1, y, cw - 2, HitRowH);
+					var selRect = new Rectangle(cx + SwatchWidth + 4, y, cw - SwatchWidth - 5, HitRowH);
 					g.FillRectangle(selectionBackBrush, selRect);
 				}
 
@@ -456,6 +456,10 @@ namespace River.OneMoreAddIn.Commands
 
 			if (hit.Value.HitIndex == -1 && card.PageId != null)
 			{
+				if (card.Hits.Count > 0)
+				{
+					SelectHit(hit.Value.CardIndex, 0);
+				}
 				CardActivated?.Invoke(this, new NavigateCardEventArgs(card.PageId));
 			}
 			else if (hit.Value.HitIndex >= 0)


### PR DESCRIPTION
## Summary

- `resultsView` background and card background now use `AppWorkspace` / `ControlLightLight` respectively, matching the `HashtagDialog` / `HashtagContextControl` color scheme in both light and dark themes
- Hit selection highlight starts to the right of the section-color swatch instead of spanning the full card width
- Clicking a page title now selects and highlights the first hit under that card, deselecting any prior selection

Relates to #2059

🤖 Generated with [Claude Code](https://claude.com/claude-code)