### PR TITLE
Fix ERR-006 - NewStyle crashes when theme has no styles

### DIFF
--- a/OneMore/Styles/Theme.cs
+++ b/OneMore/Styles/Theme.cs
@@ -207,7 +207,9 @@ namespace River.OneMoreAddIn.Styles
 			{
 				// calculate new index
 				style.Index = root.Elements(ns + "Style")
-					.Max(e => int.Parse(e.Attribute("index").Value)) + 1;
+					.Select(e => int.Parse(e.Attribute("index").Value))
+					.DefaultIfEmpty(-1)
+					.Max() + 1;
 
 				root.Add(new StyleRecord(style).ToXElement());
 			}


### PR DESCRIPTION
## Summary

- `Theme.ReplaceStyle` called `Enumerable.Max()` on an empty sequence when the active theme contained zero `<Style>` elements, throwing `InvalidOperationException`
- Fixed by inserting `.DefaultIfEmpty(-1)` before `.Max()` so an empty theme seeds the first new style at index 0
- The bulk variant `ReplaceStyles` already guards with `Any()` — this makes `ReplaceStyle` consistent

## Test plan

- [ ] Set the active theme to a custom XML with no `<Style>` children, then run **OneMore → Styles → Create a new style…** — should complete without error, style saved at index 0
- [ ] Repeat with a populated theme — new style index is still `Max(existing) + 1`

Relates to #2063

🤖 Generated with [Claude Code](https://claude.com/claude-code)