### PR TITLE
Hashtag: section color swatch and checkbox hover (#2054)

### DIFF
--- a/OneMore/Commands/Tagging/HashtagContext.cs
+++ b/OneMore/Commands/Tagging/HashtagContext.cs
@@ -5,6 +5,7 @@
 namespace River.OneMoreAddIn.Commands
 {
 	using System.Collections.Generic;
+	using System.Drawing;
 
 
 	/// <summary>
@@ -47,6 +48,12 @@ namespace River.OneMoreAddIn.Commands
 		/// Gets or sets the body-level snippets of text on the page that contain contextual tags
 		/// </summary>
 		public HashtagSnippets Snippets { get; set; }
+
+
+		/// <summary>
+		/// Gets or sets the section color to display as a left-edge swatch on the card
+		/// </summary>
+		public Color SectionColor { get; set; }
 
 
 		public bool HasSnippet(string objectID)

--- a/OneMore/Commands/Tagging/HashtagContextControl.cs
+++ b/OneMore/Commands/Tagging/HashtagContextControl.cs
@@ -15,7 +15,9 @@ namespace River.OneMoreAddIn.Commands
 
 	internal partial class HashtagContextControl : MoreUserControl
 	{
+		private const int SwatchWidth = 5;
 		private int radius = 5;
+		private Color sectionColor = Color.Empty;
 
 
 		public HashtagContextControl()
@@ -33,8 +35,21 @@ namespace River.OneMoreAddIn.Commands
 			var hoverColor = manager.GetColor("HoverColor");
 
 			PageID = item.PageID;
+			sectionColor = item.SectionColor;
 
 			checkbox.Enabled = item.Available;
+			checkbox.Visible = false;
+
+			MouseEnter += (s, e) => UpdateCheckboxVisibility();
+			MouseMove  += (s, e) => UpdateCheckboxVisibility();
+			MouseLeave += (s, e) => UpdateCheckboxVisibility();
+			pageLink.MouseEnter += (s, e) => UpdateCheckboxVisibility();
+			pageLink.MouseMove  += (s, e) => UpdateCheckboxVisibility();
+			pageLink.MouseLeave += (s, e) => UpdateCheckboxVisibility();
+			dateLabel.MouseEnter += (s, e) => UpdateCheckboxVisibility();
+			dateLabel.MouseLeave += (s, e) => UpdateCheckboxVisibility();
+			snippetsPanel.MouseEnter += (s, e) => UpdateCheckboxVisibility();
+			snippetsPanel.MouseLeave += (s, e) => UpdateCheckboxVisibility();
 
 			pageLink.Text = $"{item.HierarchyPath}/{item.PageTitle}";
 			var oid = string.IsNullOrWhiteSpace(item.TitleID) ? string.Empty : item.TitleID;
@@ -78,6 +93,8 @@ namespace River.OneMoreAddIn.Commands
 					StrictColors = true
 				};
 
+				link.MouseEnter += (s, e) => UpdateCheckboxVisibility();
+				link.MouseLeave += (s, e) => UpdateCheckboxVisibility();
 				link.LinkClicked += NavigateTo;
 				link.Links.Add(0, link.Text.Length, (item.PageID, snippet.ObjectID));
 
@@ -108,8 +125,17 @@ namespace River.OneMoreAddIn.Commands
 			set
 			{
 				checkbox.Checked = value;
+				UpdateCheckboxVisibility();
 				Checked?.Invoke(this, new EventArgs());
 			}
+		}
+
+
+		private void UpdateCheckboxVisibility()
+		{
+			var pt = PointToClient(MousePosition);
+			var inTitleRow = ClientRectangle.Contains(pt) && pt.Y < snippetsPanel.Top;
+			checkbox.Visible = IsChecked || inTitleRow;
 		}
 
 
@@ -137,6 +163,17 @@ namespace River.OneMoreAddIn.Commands
 
 			Invalidate();
 		}
+
+
+		protected override void OnPaint(PaintEventArgs e)
+		{
+			base.OnPaint(e);
+			if (sectionColor == Color.Empty) return;
+			var swatchRect = new Rectangle(0, radius, SwatchWidth, Height - radius * 2);
+			using var brush = new SolidBrush(sectionColor);
+			e.Graphics.FillRectangle(brush, swatchRect);
+		}
+
 
 		protected override void OnSizeChanged(EventArgs e)
 		{

--- a/OneMore/Commands/Tagging/HashtagDialog.cs
+++ b/OneMore/Commands/Tagging/HashtagDialog.cs
@@ -277,6 +277,21 @@ namespace River.OneMoreAddIn.Commands
 				var items = CollateTags(tags, loadedBookIDs);
 				tags.Clear();
 
+				var colorCache = new Dictionary<string, Color>();
+				foreach (var item in items)
+				{
+					if (item.SectionID is null) continue;
+					if (!colorCache.TryGetValue(item.SectionID, out var color))
+					{
+						var info = await one.GetSectionInfo(item.SectionID);
+						color = info?.Color is not null
+							? ColorHelper.FromHtml(info.Color)
+							: Color.Empty;
+						colorCache[item.SectionID] = color;
+					}
+					item.SectionColor = color;
+				}
+
 				var controls = new HashtagContextControl[items.Count];
 
 				for (var i = 0; i < items.Count; i++)


### PR DESCRIPTION
Relates to #2054

- Draw a 5px vertical swatch on the left edge of each card using the section's accent color, inset by the corner radius to stay within the rounded region
- Fetch section colors after collation in SearchTags, cached per SectionID to avoid redundant COM calls
- Hide checkbox by default; show only when mouse is over the title row (Y < snippetsPanel.Top), matching search dialog hoverHit == -1 behavior; checkbox stays visible when checked


## IS YOUR COMMIT SIGNED?
Note that this repo requires all commits to be properly signed, [see here](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more info

## Enhancement or Defect Addressed by This PR
What...

## Description of Proposed Changes
How...
