### PR TITLE
guard against null filler in FillAcross and FillDown

### DIFF
--- a/OneMore/Commands/Tables/FillCellsCommand.cs
+++ b/OneMore/Commands/Tables/FillCellsCommand.cs
@@ -190,6 +190,7 @@ namespace River.OneMoreAddIn.Commands
 				{
 					// only one cell to fill, no pattern so increment by 1
 					filler = GetFiller(table[ri][minCol]);
+					if (filler == null) continue;
 				}
 				else
 				{
@@ -235,6 +236,7 @@ namespace River.OneMoreAddIn.Commands
 				{
 					// only one cell to fill, no pattern so increment by 1
 					filler = GetFiller(table[minRow][ci]);
+					if (filler == null) continue;
 				}
 				else
 				{


### PR DESCRIPTION
When exactly two columns (or rows) are selected and the source cell contains unrecognised content, GetFiller returns null but amount stays at 1, causing a NullReferenceException. Skip the row/column with continue, matching the behaviour of the already-safe Analyze path.

Relates to #2067

