### PR TITLE
2088 enhance markdown capabilities

### DIFF
--- a/OneMore/Commands/File/ImportCommand.cs
+++ b/OneMore/Commands/File/ImportCommand.cs
@@ -682,6 +682,7 @@ namespace River.OneMoreAddIn.Commands
 
 					converter = new MarkdownConverter(page);
 					converter.RewriteHeadings();
+					converter.RewriteTodo();
 
 					logger.WriteLine($"updating...");
 					logger.WriteLine(page.Root);

--- a/OneMore/Commands/File/Markdown/MarkdownConverter.cs
+++ b/OneMore/Commands/File/Markdown/MarkdownConverter.cs
@@ -55,6 +55,18 @@ namespace River.OneMoreAddIn.Commands
 
 
 		/// <summary>
+		/// Tags current lines with To Do tags if beginning with [ ] or [x] in all Outlines
+		/// </summary>
+		public void RewriteTodo()
+		{
+			foreach (var outline in page.BodyOutlines)
+			{
+				RewriteTodo(outline.Descendants(ns + "OE"));
+			}
+		}
+
+
+		/// <summary>
 		/// Applies standard OneNote styling all recognizable headings in the given Outline
 		/// </summary>
 		public MarkdownConverter RewriteHeadings(IEnumerable<XElement> paragraphs)

--- a/OneMore/Commands/File/Markdown/MarkdownWriter.cs
+++ b/OneMore/Commands/File/Markdown/MarkdownWriter.cs
@@ -152,7 +152,7 @@ namespace River.OneMoreAddIn.Commands
 
 
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		/// <param name="container">typically an OEChildren with elements and OEChildren</param>
 		/// <param name="prefix">prefix used to indent markdown lines</param>
@@ -168,13 +168,28 @@ namespace River.OneMoreAddIn.Commands
 
 			logger.Debug($"Write({container.Name.LocalName}, prefix:[{prefix}], depth:{depth}, contained:{contained})");
 
-			foreach (var element in container.Elements())
+			// For OE containers: ensure the List element (bullet/number marker) is processed
+			// before any Tag elements so output order is "- [x] text" not "[x] - text"
+			IEnumerable<XElement> children = container.Elements();
+			if (container.Name.LocalName == "OE"
+				&& container.Elements(ns + "List").Any()
+				&& container.Elements(ns + "Tag").Any())
 			{
+				var listElem = container.Element(ns + "List");
+				children = children
+					.Where(e => !ReferenceEquals(e, listElem))
+					.Prepend(listElem);
+			}
+
+			var elements = children.ToList();
+			for (int ei = 0; ei < elements.Count; ei++)
+			{
+				var element = elements[ei];
 				var n = element.Name.LocalName;
 				var m = $"- [prefix:[{prefix}] depth:{depth} start:{startOfLine} contained:{contained} element {n}";
 				logger.Debug(n == "T" ? $"{m} [{element.Value}]" : m);
 
-				switch (element.Name.LocalName)
+				switch (n)
 				{
 					case "OEChildren":
 						Write(element, $"{Indent}{prefix}", depth + 1, contained);
@@ -182,6 +197,28 @@ namespace River.OneMoreAddIn.Commands
 
 					case "OE":
 						{
+							// Detect a run of consecutive code-block OEs and emit as a fenced block
+							if (IsCodeBlockOE(element))
+							{
+								var codeLines = new List<XElement> { element };
+								while (ei + 1 < elements.Count
+									&& elements[ei + 1].Name.LocalName == "OE"
+									&& IsCodeBlockOE(elements[ei + 1]))
+								{
+									ei++;
+									codeLines.Add(elements[ei]);
+								}
+
+								if (!contained) writer.WriteLine();
+								writer.WriteLine("```");
+								foreach (var codeLine in codeLines)
+								{
+									writer.WriteLine(GetCodeText(codeLine));
+								}
+								writer.WriteLine("```");
+								break;
+							}
+
 							if (!contained) // not in table cell
 							{
 								writer.WriteLine("  ");
@@ -205,17 +242,20 @@ namespace River.OneMoreAddIn.Commands
 
 					case "Tag":
 						{
-							// should always be startOfLine
 							var context = DetectQuickStyle(element);
-							if (context is not null)
+							// Only write line prefix at start of line; when a List element has already
+							// been processed first (Tag+List reordering above), the list marker wrote
+							// the prefix so we must not write it again.
+							if (startOfLine)
 							{
-								Stylize(depth > 0
-									? prefix /*new String(Quote[0], depth)*/
-									: string.Empty);
-							}
-							else
-							{
-								writer.Write(prefix);
+								if (context is not null)
+								{
+									Stylize(depth > 0 ? prefix : string.Empty);
+								}
+								else
+								{
+									writer.Write(prefix);
+								}
 							}
 
 							WriteTag(element);
@@ -235,7 +275,7 @@ namespace River.OneMoreAddIn.Commands
 							if (context is not null)
 							{
 								Stylize(depth > 0 && startOfLine
-									? prefix /*new String(Quote[0], depth)*/
+									? prefix
 									: string.Empty);
 
 								startOfLine = false;
@@ -296,6 +336,35 @@ namespace River.OneMoreAddIn.Commands
 			}
 
 			logger.Debug("out");
+		}
+
+
+		private bool IsCodeBlockOE(XElement oe)
+		{
+			// Check the OE itself then its parent (OEChildren) for a code quickstyle.
+			// Only OE-level code style indicates a standalone code block; a code style
+			// on an inner T is inline code handled by DetectQuickStyle in the T case.
+			if (!oe.GetAttributeValue("quickStyleIndex", out int index, -1))
+			{
+				if (oe.Parent == null
+					|| !oe.Parent.GetAttributeValue("quickStyleIndex", out index, -1))
+				{
+					return false;
+				}
+			}
+
+			var quick = quickStyles.FirstOrDefault(q => q.Index == index);
+			return quick?.Name?.ToLower().Contains("code") == true;
+		}
+
+
+		private string GetCodeText(XElement oe)
+		{
+			// Return plain text content of a code-block OE, stripping any HTML span tags
+			// that may be present (e.g., syntax-highlighting colors).
+			var cdata = oe.Elements(ns + "T").FirstOrDefault()?.GetCData();
+			if (cdata == null) return string.Empty;
+			return cdata.GetWrapper().Value.TrimEnd();
 		}
 
 
@@ -409,10 +478,20 @@ namespace River.OneMoreAddIn.Commands
 		{
 			cdata.Value = cdata.Value
 				.Replace("<br>", "  ") // usually followed by NL so leave it there
-				.Replace("[", "\\[")   // escape to prevent confusion with md links
 				.TrimEnd();
 
 			var wrapper = cdata.GetWrapper();
+
+			// Escape markdown-significant characters in text nodes only, before span and
+			// anchor processing so href attribute values are never inadvertently escaped.
+			// New XText nodes created by anchor replacement below are not revisited.
+			foreach (var textNode in wrapper.DescendantNodes().OfType<XText>().ToList())
+			{
+				textNode.Value = textNode.Value
+					.Replace("[", "\\[")
+					.Replace("|", "\\|");
+			}
+
 			foreach (var span in wrapper.Descendants("span").ToList())
 			{
 				var text = span.Value;
@@ -420,15 +499,18 @@ namespace River.OneMoreAddIn.Commands
 				// span might only have a lang attribute
 				if (att != null)
 				{
-					var style = new Style(span.Attribute("style").Value);
+					var style = new Style(att.Value);
 					if (style.IsStrikethrough) text = $"~~{text}~~";
 					if (style.IsItalic) text = $"*{text}*";
 					if (style.IsBold) text = $"**{text}**";
+					if (style.IsUnderline) text = $"<u>{text}</u>";
+					if (style.IsSuperscript) text = $"<sup>{text}</sup>";
+					if (style.IsSubscript) text = $"<sub>{text}</sub>";
 				}
 				span.ReplaceWith(new XText(text));
 			}
 
-			foreach (var anchor in wrapper.Elements("a"))
+			foreach (var anchor in wrapper.Elements("a").ToList())
 			{
 				var href = anchor.Attribute("href")?.Value;
 				if (!string.IsNullOrEmpty(href))
@@ -445,10 +527,9 @@ namespace River.OneMoreAddIn.Commands
 				}
 			}
 
-			// escape directives
+			// escape remaining directives (| and [ already escaped in text nodes above)
 			var raw = wrapper.GetInnerXml()
-				.Replace("&lt;", "\\<")
-				.Replace("|", "\\|");
+				.Replace("&lt;", "\\<");
 
 			if (startOfLine && raw.Length > 0 && raw.StartsWith("#"))
 			{


### PR DESCRIPTION
Relates to #2088

## Summary

Six correctness and coverage fixes to the markdown import/export subsystem. Each change is independent and addresses a specific bug or gap found during analysis of the existing code and PR #1647.

### Export — `MarkdownWriter`

- **Fix `[` in href attributes being escaped** — `cdata.Value.Replace("[", "\[")` ran on the raw CDATA string before XML parsing, which corrupted `[` inside `href` attribute values (e.g. Wikipedia-style URLs). Escaping of `[` and `|` is now done per `XText` node only, so attribute values are never touched.

- **Fix `|` in URLs being escaped to `\|`** — the same per-text-node approach leaves `|` in link destinations alone, preventing mangled URLs in table-cell content.

- **Fix Tag + Bullet emitting wrong order** — OneNote XML orders children `Tag → List → T`, so the old code produced `[x] - item text` instead of `- [x] item text`. OE children are now reordered when both `Tag` and `List` are present, and the Tag case guards its prefix write with `startOfLine`.

- **Fenced code blocks** — consecutive OEs with a `code` quickstyle are now emitted as a triple-backtick fenced block instead of per-line inline backticks.

- **Underline / superscript / subscript** — `Style.IsUnderline`, `.IsSuperscript`, `.IsSubscript` were parsed but never emitted. They now render as `<u>`, `<sup>`, `<sub>` inline HTML (valid CommonMark, rendered by GitHub and most viewers).

### Import — `MarkdownConverter` / `ImportCommand`

- **`RewriteTodo()` never called during file import** — `ImportMarkdownFile` called `RewriteHeadings()` twice but never `RewriteTodo()`, so `[ ]`/`[x]` task-list items remained as plain text. A page-level `RewriteTodo()` overload (mirroring the existing `RewriteHeadings()` pattern) is added and called in pass 2. `ConvertMarkdownCommand` already called it correctly.

## Notes on PR #1647

Changes from PR #1647 were considered but taken selectively:
- The URL-escaping insight (angle brackets) informed the per-text-node approach used here, which is simpler and avoids XML-encoding issues.
- The `MatchHeading` font-family gate (`if (style.FontFamily == "Calibri")`) from that PR was **not** adopted — it breaks heading detection on OneNote 2023+ which defaults to Aptos. The existing code explicitly avoids this gate.
- The `PrefixClass` refactor and nested-table HTML approach were not adopted.

## Test plan

- [ ] Create a page with: h1–h6 headings, bold/italic/underline/strikethrough/superscript/subscript text, bulleted list with to-do tagged items, numbered list, multi-line code block (`code` quickstyle), a table with pipe-containing URL in a cell, an image, an external hyperlink whose URL contains `[` or `|`
- [ ] Export as markdown, inspect the `.md` file:
  - Tagged bullet items: `- [x] text` (not `[x] - text`)
  - Code blocks: triple-backtick fenced (not per-line backticks)
  - URLs with `|` or `[`: unescaped inside the link destination
  - Underline → `<u>`, superscript → `<sup>`, subscript → `<sub>`
- [ ] Create a `.md` file with `- [ ] todo`, `- [x] done`, headings, fenced code block; import it
  - Task items become OneNote to-do tags
  - Headings get `quickStyleIndex` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)