### PR TITLE
1841 convert task list items to OneNote to-do tags on import

### DIFF
--- a/OneMore/Commands/File/Markdown/OneMoreDig.cs
+++ b/OneMore/Commands/File/Markdown/OneMoreDig.cs
@@ -20,11 +20,19 @@ namespace River.OneMoreAddIn.Commands
 				BaseUrl = new Uri($"{Path.GetDirectoryName(path)}/")
 			};
 
-			var pipeline = new MarkdownPipelineBuilder()
+			var builder = new MarkdownPipelineBuilder()
 				.UseAdvancedExtensions()
 				.UseOneMoreExtensions()
-				.UseWikilinks()
-				.Build();
+				.UseWikilinks();
+
+			// Remove the TaskList extension so "- [ ]" and "- [x]" are rendered as plain
+			// list items with literal "[ ]"/"[x]" text. If TaskList is active it converts
+			// these to <input type="checkbox"> which OneNote strips, losing the checkbox
+			// information before MarkdownConverter.RewriteTodo() can act on it.
+			builder.Extensions.RemoveAll(
+				e => e.GetType().Name == "TaskListExtension");
+
+			var pipeline = builder.Build();
 
 			pipeline.Setup(renderer);
 


### PR DESCRIPTION
Relates to #1841

## Summary

Markdown `- [ ]` and `- [x]` task list items were silently lost when importing or converting markdown — they ended up as plain bullets with no checkbox. This fixes that for both **File → Import Markdown** and **Convert Markdown** (in-place).

## Root cause

`UseAdvancedExtensions()` in Markdig includes the `TaskList` extension, which converts:

```
- [ ] buy milk
- [x] done
```
→
```html
<li><input type="checkbox" disabled> buy milk</li>
<li><input type="checkbox" disabled checked> done</li>
```

OneNote strips unsupported `<input>` elements entirely, so by the time `MarkdownConverter.RewriteTodo()` runs it sees a plain bullet with text `buy milk` — no `[ ]` to match on.

## Fix

Remove `TaskListExtension` from the Markdig pipeline in `OneMoreDig.ConvertMarkdownToHtml()`. Without it, `- [ ] text` is rendered as a regular `<li>[ ] text</li>`. OneNote imports that as a bullet item with literal `[ ] text`, and the existing `RewriteTodo()` logic converts it to a to-do tag and strips the `[ ]` prefix.

The same fix makes **Convert Markdown** work correctly too — it already called `RewriteTodo()` but the `[ ]` was being stripped by Markdig before `RewriteTodo()` ever saw it.

## Test plan

- [x] Create a `.md` file with `- [ ] unchecked item` and `- [x] checked item`; import via **File → Import Markdown** — both items should become OneNote to-do checkboxes (unchecked and checked respectively)
- [x] Type `- [ ] todo` and `- [x] done` on a OneNote page; select all and run **Convert Markdown** — same result
- [x] Normal bullet lists without `[ ]` should be unaffected
- [x] Nested task lists (`  - [ ] sub-item`) should also convert correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)