### PR TITLE
1969 fix Copy as Markdown for single paragraph selection

### DIFF
--- a/OneMore/Commands/Edit/CopyAsMarkdownCommand.cs
+++ b/OneMore/Commands/Edit/CopyAsMarkdownCommand.cs
@@ -22,7 +22,7 @@ namespace River.OneMoreAddIn.Commands
 
 		public override async Task Execute(params object[] args)
 		{
-			async void WriteMarkdown(PageEditor editor, MarkdownWriter writer, XElement start)
+			async void WriteMarkdown(PageEditor editor, MarkdownWriter writer, XElement start, bool includeTitle)
 			{
 				var content = editor.ExtractSelectedContent(start);
 
@@ -30,7 +30,7 @@ namespace River.OneMoreAddIn.Commands
 				logger.Debug(content);
 				logger.Debug("- - -");
 
-				await writer.Copy(content);
+				await writer.Copy(content, includeTitle);
 			}
 
 			// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -39,9 +39,11 @@ namespace River.OneMoreAddIn.Commands
 
 			var writer = new MarkdownWriter(page, false);
 
-			// discover selection scope
+			// discover selection scope; allowNonEmpty lets a within-paragraph Run selection
+			// through — without it GetSelection() resets Run scope to None and the command
+			// returns early without writing anything to the clipboard
 			var range = new SelectionRange(page);
-			range.GetSelection();
+			range.GetSelection(allowNonEmpty: true);
 
 			if (range.Scope == SelectionScope.None)
 			{
@@ -61,12 +63,12 @@ namespace River.OneMoreAddIn.Commands
 
 					foreach (var outline in page.BodyOutlines)
 					{
-						WriteMarkdown(editor, writer, outline);
+						WriteMarkdown(editor, writer, outline, true);
 					}
 				}
 				else
 				{
-					WriteMarkdown(editor, writer, null);
+					WriteMarkdown(editor, writer, null, false);
 				}
 			}
 			catch (Exception exc)

--- a/OneMore/Commands/File/Markdown/MarkdownWriter.cs
+++ b/OneMore/Commands/File/Markdown/MarkdownWriter.cs
@@ -74,12 +74,16 @@ namespace River.OneMoreAddIn.Commands
 		/// page as a template for tag and style references.
 		/// </summary>
 		/// <param name="content"></param>
-		public async Task Copy(XElement content)
+		/// <param name="includeTitle">True to prepend the page title as an H1 heading</param>
+		public async Task Copy(XElement content, bool includeTitle = true)
 		{
 			using var stream = new MemoryStream();
 			using (writer = new StreamWriter(stream))
 			{
-				await writer.WriteLineAsync($"# {page.Title}");
+				if (includeTitle)
+				{
+					await writer.WriteLineAsync($"# {page.Title}");
+				}
 
 				if (content.Name.LocalName == "Page")
 				{


### PR DESCRIPTION
## Summary

- Fix `CopyAsMarkdownCommand` ignoring within-paragraph (Run scope) selections by passing `allowNonEmpty: true` to `GetSelection()` — previously the scope was reset to `None` and nothing was written to the clipboard
- Omit the page title (`# Page Title`) from clipboard output when less than 100% of the page is selected; full-page copy (`TextCursor` scope) still includes the title

## Test plan

- [x] Place cursor inside a paragraph (no selection) → Copy as Markdown → clipboard should contain full page markdown including `# Title`
- [x] Select a word or phrase within a single paragraph → Copy as Markdown → clipboard should contain only the selected text as markdown, without `# Title`
- [x] Select one or more complete paragraphs → Copy as Markdown → clipboard contains the selected paragraphs without `# Title`
- [ ] Select the full page → Copy as Markdown → clipboard contains full page markdown with `# Title`

Relates to #1969

🤖 Generated with [Claude Code](https://claude.com/claude-code)