### PR TITLE
1806 preserve blank paragraphs in Convert Markdown

### DIFF
--- a/OneMore/Models/PageReader.cs
+++ b/OneMore/Models/PageReader.cs
@@ -648,6 +648,12 @@ namespace River.OneMoreAddIn.Models
 					}
 				}
 			}
+			else if (ParagraphDivider is not null)
+			{
+				// preserve blank paragraphs as empty lines so markdown section separators
+				// (e.g. "---" thematic breaks, code fences) parse correctly
+				builder.AppendLine();
+			}
 
 			var children = paragraph
 				.Elements(ns + "OEChildren")


### PR DESCRIPTION
## Summary

- `PageReader.BuildText` silently skipped empty OEs for all callers. For the markdown-configured callers (`ConvertMarkdownCommand`, `PreviewMarkdownCommand`), those empty OEs represent blank paragraph separators the user intentionally pasted into OneNote between markdown sections.
- Without them, Markdig sees content like `## Heading\n---\n## Next Heading` and interprets the `---` as a SetExt heading underline (promoting the preceding heading text) rather than a thematic break. Similarly, blank lines around code fences and blockquotes are required for correct parsing.
- Fix: when `ParagraphDivider` is set (markdown-only callers), emit `AppendLine()` for empty OEs to preserve paragraph separation. `CopyAsTextCommand` uses `ParagraphDivider = null` and is unaffected.

## Test plan

- [ ] Paste a markdown document containing `---` horizontal rules, fenced code blocks, and blockquotes into OneNote as plain text
- [ ] Select all and run **Edit / Convert Markdown**
- [ ] Verify `---` renders as a horizontal rule (not as a heading underline)
- [ ] Verify fenced code blocks render as code
- [ ] Verify content after a code block continues to convert correctly
- [ ] Run **Edit / Copy as Text** on a page with blank paragraphs and confirm output is unchanged

Relates to #1806

🤖 Generated with [Claude Code](https://claude.com/claude-code)