### PR TITLE
2007 Fix Increase Font Size hotkey blocked on non-US locales

### DIFF
--- a/OneMore/AddInHotkeys.cs
+++ b/OneMore/AddInHotkeys.cs
@@ -39,15 +39,12 @@ namespace River.OneMoreAddIn
 					Command = (CommandAttribute)m.Attributes[0]
 				});
 
-			// an awful hack to avoid a conflict with Italian keyboard (FIGS and likely UK) that
-			// use AltGr as Ctrl+Alt. This means users pressing AltGr+OemPlus to get a square
-			// bracket would instead end up increasing the font size of the page when they didn't
-			// mean to! So here we only register these hot keys for the US keyboard input layout.
+			// On non-US keyboards (e.g. Italian, UK) AltGr is Ctrl+Alt, so Ctrl+Alt+OemPlus
+			// conflicts with AltGr+= which produces a square bracket on those layouts.
+			// We skip registration of any OemPlus-based hotkey on non-US locales below,
+			// but only for the default binding — if the user has configured a different key
+			// we honor that choice regardless of locale.
 			var locale = System.Threading.Thread.CurrentThread.CurrentCulture.KeyboardLayoutId;
-			if (locale != en_US_Locale)
-			{
-				methods = methods.Where(m => m.Method.Name != nameof(IncreaseFontSizeCmd));
-			}
 
 			if (!methods.Any())
 			{
@@ -87,6 +84,12 @@ namespace River.OneMoreAddIn
 							hotkey = new Hotkey(keys);
 						}
 					}
+				}
+
+				// Skip OemPlus-based bindings on non-US keyboards to avoid AltGr conflict
+				if (locale != en_US_Locale && hotkey?.Keys == Keys.Oemplus)
+				{
+					hotkey = null;
 				}
 
 				if (hotkey != null && hotkey.Keys != Keys.None)


### PR DESCRIPTION
## Summary

- The `Ctrl+Alt++` hotkey for Increase Font Size was silently suppressed for all non-US keyboard locales (e.g. Swedish, French, German) due to an AltGr conflict guard on Italian/UK layouts
- The guard ran before user-configured key overrides were resolved, so a custom binding to a non-conflicting key was also ignored
- Moved the OemPlus conflict check inside the per-command loop, after the user override is applied — default `Ctrl+Alt++` is still blocked on non-US locales (AltGr protection preserved), but a user-configured alternative key now registers correctly

## Test plan

- [ ] On a US locale: verify `Ctrl+Alt++` increases font size and `Ctrl+Alt+-` decreases it
- [ ] On a non-US locale (or by temporarily changing `en_US_Locale` to a non-matching value): verify the default `Ctrl+Alt++` hotkey is **not** registered (no accidental AltGr trigger)
- [ ] On a non-US locale with a custom override key (e.g. `Ctrl+Shift+F9`) set via OneMore keyboard settings: verify the custom key **does** register and increases font size

Relates to #2007

🤖 Generated with [Claude Code](https://claude.com/claude-code)