### PR TITLE
1237 fix Apply Styles to Page resetting list marker styles in heading paragraphs

### DIFF
--- a/OneMore/Commands/Styles/ApplyStylesCommand.cs
+++ b/OneMore/Commands/Styles/ApplyStylesCommand.cs
@@ -305,41 +305,37 @@ namespace River.OneMoreAddIn.Commands
 
 		private void ApplyToLists(IEnumerable<Style> styles)
 		{
-			var style = styles.SingleOrDefault(s =>
+			var quickDefs = page.Root.Elements(ns + "QuickStyleDef").ToList();
+
+			var normalStyle = styles.SingleOrDefault(s =>
 				s.Name.ToLower() == "normal" ||
 				s.Name.ToLower() == "body" ||
-				s.Name.ToLower() == "p");
+				s.Name.ToLower() == "p")
+				?? new Style { Color = page.GetBestTextColor().ToRGBHtml() };
 
-			style ??= new Style
+			Style StyleFor(XElement listItem)
 			{
-				Color = page.GetBestTextColor().ToRGBHtml()
-			};
-
-			var elements = page.Root.Descendants(ns + "Bullet");
-			if (elements?.Any() == true)
-			{
-				ApplyToListItems(elements, style, false);
+				var qsi = listItem.Parent?.Parent?.Attribute("quickStyleIndex")?.Value;
+				if (qsi == null) return normalStyle;
+				var quickName = quickDefs
+					.FirstOrDefault(q => q.Attribute("index")?.Value == qsi)
+					?.Attribute("name")?.Value;
+				return quickName != null ? (FindStyle(styles, quickName) ?? normalStyle) : normalStyle;
 			}
 
-			elements = page.Root.Descendants(ns + "Number");
-			if (elements?.Any() == true)
+			foreach (var element in page.Root.Descendants(ns + "Bullet").ToList())
 			{
-				ApplyToListItems(elements, style, true);
+				var s = StyleFor(element);
+				element.SetAttributeValue("fontColor", s.Color);
+				element.SetAttributeValue("fontSize", s.FontSize);
 			}
-		}
 
-
-		private static void ApplyToListItems(IEnumerable<XElement> elements, Style style, bool withFamily)
-		{
-			foreach (var element in elements)
+			foreach (var element in page.Root.Descendants(ns + "Number").ToList())
 			{
-				element.SetAttributeValue("fontColor", style.Color);
-				element.SetAttributeValue("fontSize", style.FontSize);
-
-				if (withFamily)
-				{
-					element.SetAttributeValue("font", style.FontFamily);
-				}
+				var s = StyleFor(element);
+				element.SetAttributeValue("fontColor", s.Color);
+				element.SetAttributeValue("fontSize", s.FontSize);
+				element.SetAttributeValue("font", s.FontFamily);
 			}
 		}
 


### PR DESCRIPTION
## Summary

- `ApplyStylesCommand.ApplyToLists` was resolving a single Normal/body style and applying it to **every** `Number`/`Bullet` element on the page
- This clobbered the colour and font size on list markers inside heading paragraphs (e.g. `fontColor="#1E4E79" fontSize="16.0"` → `fontColor="#000000" fontSize="11.5"`)
- Fix resolves the appropriate custom style per element: walks up to the parent `OE`, reads its `quickStyleIndex`, maps to the `QuickStyleDef` name, and calls the existing `FindStyle` helper — falling back to Normal/body when no match is found
- Removed the now-unused `ApplyToListItems` helper

## Test plan

- [x] Create a page with a normal numbered list, a Heading 1 numbered list, and a Heading 2 numbered list
- [x] Run **More → Custom Styles → Apply Styles to Page**
- [x] Inspect XML: Normal `Number` elements get Normal style colour/size; Heading 1 `Number` elements get Heading 1 colour/size; Heading 2 `Number` elements get Heading 2 colour/size
- [x] Visually confirm markers render in heading colour, not body colour

Relates to #1237

🤖 Generated with [Claude Code](https://claude.com/claude-code)