### PR TITLE
1036 fix Apply Styles to Page leaving unmatched QuickStyleDefs with stale font

### DIFF
--- a/OneMore/Commands/Styles/ApplyStylesCommand.cs
+++ b/OneMore/Commands/Styles/ApplyStylesCommand.cs
@@ -170,6 +170,20 @@ namespace River.OneMoreAddIn.Commands
 
 					applied = true;
 				}
+				else if (name != "code")
+				{
+					// No custom theme style matched this QuickStyleDef. Sync font to the
+					// current OneNote default so pages created under an old default font
+					// render correctly after the user changes their default font.
+					quick.Attribute("font").Value = StyleBase.DefaultFontFamily;
+					if (name == "p")
+					{
+						quick.Attribute("fontSize").Value =
+							StyleBase.DefaultFontSize.ToString("0.0", CultureInfo.InvariantCulture);
+					}
+
+					applied = true;
+				}
 
 				var index = quick.Attribute("index").Value;
 


### PR DESCRIPTION
## Summary

- When a page is created under default font A and the user later changes their OneNote default to B, embedded `QuickStyleDef` elements on the page retain font A — OneNote never updates them.
- **Apply Styles to Page** already updates QuickStyleDefs that match a custom theme style, but left unmatched ones (headings, PageTitle, etc. not in the theme) with the stale font. It also clears any inline font overrides, so those paragraphs reverted to the old font A.
- Fix: for any QuickStyleDef with no matching custom theme style, sync its `font` attribute to `StyleBase.DefaultFontFamily` (current OneNote default from registry). Also sync `fontSize` for the normal `"p"` style. The `"code"` style is excluded — it intentionally uses a monospace font.

## Test plan

- [x] Create a page while default font is Calibri; verify QuickStyleDefs have Calibri
- [x] Change OneNote default font to a visually distinct font (e.g. Georgia)
- [x] Run **Apply Styles to Page** with a theme that does NOT define all heading styles
- [x] Confirm unmatched heading paragraphs now render in Georgia, not Calibri
- [x] Confirm code paragraphs are unchanged (still monospace)
- [x] Confirm custom-styled paragraphs still use the font from the theme
- [x] Run with a theme that defines all styles — verify no regression

Relates to #1036

🤖 Generated with [Claude Code](https://claude.com/claude-code)