### PR TITLE
2100 fix CaptionAttachments failing on printout attachments

### DIFF
--- a/OneMore/Commands/Page/CaptionAttachmentsCommand.cs
+++ b/OneMore/Commands/Page/CaptionAttachmentsCommand.cs
@@ -60,6 +60,17 @@ namespace River.OneMoreAddIn.Commands
 
 				file.Attribute("selected")?.Remove();
 
+				// floating InsertedFiles (printout attachments) are direct Page children with
+				// Position/Size children; remove those before the LINQ clone is made so the
+				// clone inside the OE is clean (Position/Size are invalid inside an OE context)
+				var posElement = file.Element(ns + "Position");
+				var isFloating = file.Parent.Name.LocalName == "Page";
+				if (isFloating)
+				{
+					posElement?.Remove(); // detached; reused for Outline positioning below
+					file.Element(ns + "Size")?.Remove();
+				}
+
 				var table = new Table(ns);
 				table.AddColumn(0f); // OneNote will set width accordingly
 
@@ -88,7 +99,31 @@ namespace River.OneMoreAddIn.Commands
 				var style = GetStyle();
 				new Stylizer(style).ApplyStyle(cdata);
 
-				file.ReplaceWith(table.Root);
+				if (isFloating)
+				{
+					// OneNote doesn't remove the original page-level object during UpdatePageContent;
+					// force deletion by objectID first (same pattern as AddCaptionCommand)
+					var fileId = file.Attribute("objectID")?.Value;
+					if (fileId != null)
+					{
+						one.DeleteContent(page.PageId, fileId);
+					}
+
+					// wrap the table in an Outline positioned where the original attachment was
+					var outline = new XElement(ns + "Outline",
+						posElement ?? new XElement(ns + "Position",
+							new XAttribute("x", "36.0"),
+							new XAttribute("y", "36.0"),
+							new XAttribute("z", "1")),
+						new XElement(ns + "OEChildren",
+							new XElement(ns + "OE", table.Root)));
+
+					file.ReplaceWith(outline);
+				}
+				else
+				{
+					file.ReplaceWith(table.Root);
+				}
 
 				updated = true;
 			}


### PR DESCRIPTION
Relates to #2100

Printout attachments are floating InsertedFile elements (direct Page children with Position/Size children). The old code called file.ReplaceWith(table.Root) unconditionally, placing a Table at the page level (schema-invalid). The LINQ clone of file also carried Position/Size into the OE context (also invalid), triggering "0x80042001 The XML is invalid".

Fix: detect floating files (parent == Page), strip Position/Size before the LINQ clone is made, then wrap the caption table in an Outline at the original coordinates and call DeleteContent to remove the orphaned page-level object, matching the pattern used by AddCaptionCommand for floating images.


## IS YOUR COMMIT SIGNED?
Note that this repo requires all commits to be properly signed, [see here](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for more info

## Enhancement or Defect Addressed by This PR
What...

## Description of Proposed Changes
How...
