### PR TITLE
1314 apply code style when wrapping selected text in a code box

### DIFF
--- a/OneMore/Commands/Snippets/InsertBoxCommand.cs
+++ b/OneMore/Commands/Snippets/InsertBoxCommand.cs
@@ -5,6 +5,7 @@
 namespace River.OneMoreAddIn.Commands
 {
 	using River.OneMoreAddIn.Models;
+	using River.OneMoreAddIn.Styles;
 	using System;
 	using System.Collections.Generic;
 	using System.Drawing;
@@ -151,6 +152,11 @@ namespace River.OneMoreAddIn.Commands
 
 				cell.SetContent(content);
 
+				if (addTitle)
+				{
+					ApplyCodeStyle(page, content);
+				}
+
 				var shading = DetermineShading(page, content);
 				if (shading is not null)
 				{
@@ -260,6 +266,49 @@ namespace River.OneMoreAddIn.Commands
 					),
 				new Paragraph(string.Empty)
 				);
+		}
+
+
+		private void ApplyCodeStyle(Page page, XElement content)
+		{
+			var styles = new ThemeProvider().Theme.GetStyles();
+			var codeStyle = styles.FirstOrDefault(s => s.IsCode)
+				?? styles.SingleOrDefault(s => s.Name.ToLower() == "code")
+				?? styles.SingleOrDefault(s => s.Name.ToLower() == "source code");
+
+			if (codeStyle is null)
+			{
+				codeStyle = new Style(StandardStyles.Code.GetDefaults())
+				{
+					ApplyColors = false
+				};
+			}
+
+			var quick = page.GetQuickStyle(StandardStyles.Code);
+			var quicks = quick.Index.ToString();
+			var stylizer = new Stylizer(codeStyle);
+			var css = codeStyle.ToCss();
+
+			foreach (var paragraph in content.Descendants(ns + "OE")
+				.Where(e => e.Attribute("quickStyleIndex")?.Value != quicks))
+			{
+				// Gray: remove default gray formatting but preserve explicit colors (syntax highlighting)
+				stylizer.Clear(paragraph, Stylizer.Clearing.Gray, deep: false);
+
+				paragraph.SetAttributeValue("quickStyleIndex", quick.Index);
+
+				var attr = paragraph.Attribute("style");
+				if (attr is null)
+					paragraph.Add(new XAttribute("style", css));
+				else
+					attr.Value = css;
+
+				paragraph.SetAttributeValue("spaceBefore", codeStyle.SpaceBefore);
+				paragraph.SetAttributeValue("spaceAfter", codeStyle.SpaceAfter);
+
+				if (codeStyle.Ignored)
+					paragraph.SetAttributeValue("lang", "yo");
+			}
 		}
 
 

--- a/OneMore/Styles/StandardStyles.cs
+++ b/OneMore/Styles/StandardStyles.cs
@@ -32,7 +32,8 @@ namespace River.OneMoreAddIn.Styles
 				Name = key.ToName(),
 				FontFamily = StyleBase.DefaultFontFamily, // "Calibri",
 				FontSize = StyleBase.DefaultFontSize.ToString("#.0"), // "11.0",
-				Color = "#000000"
+				Color = "#000000",
+				StyleType = StyleType.Paragraph
 			};
 
 			switch (key)
@@ -90,8 +91,7 @@ namespace River.OneMoreAddIn.Styles
 					break;
 
 				case StandardStyles.Code:
-					// this FontFamily is a customization
-					style.FontFamily = StyleBase.DefaultCodeFamily; // "Consolas";
+					style.FontFamily = StyleBase.DefaultCodeFamily;
 					style.Ignored = true;
 					break;
 			}


### PR DESCRIPTION
## Summary

- When selected text is wrapped in a code box (`InsertCodeBoxCommand`), the current theme's code style is now applied to each paragraph that doesn't already carry the code `quickStyleIndex`
- Preserves explicit colors (e.g., syntax highlighting) using `Clearing.Gray`; only clears gray/default formatting
- Text boxes (`InsertTextBoxCommand`) are unaffected

Relates to #1314

## Test plan

- [x] Select text with mixed styles (heading, body, bold) → Insert > More > Code Box → confirm text renders in theme code font with code quickstyle
- [x] Select text that already uses the code quickstyle → confirm it is left unchanged
- [x] Confirm any syntax-colored text retains its colors inside the box
- [x] Insert a code box with no selection (cursor only) → confirm default placeholder content is unchanged
- [x] Insert a text box (non-code) with a selection → confirm no style is applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)